### PR TITLE
fix/ppb 49 move case filtering to backend

### DIFF
--- a/apps/web/src/app/views/home/controller.js
+++ b/apps/web/src/app/views/home/controller.js
@@ -12,24 +12,9 @@ import {
 	getSimplifiedEvents
 } from '../../calendar/calendar.js';
 import { parse as parseUrl } from 'url';
+import { normalizeFilters, validateFilters } from '@pins/inspector-programming-lib/util/filtering.js';
 import { addSessionData, readSessionData } from '@pins/inspector-programming-lib/util/session.js';
 import { formatDateForDisplay } from '@pins/inspector-programming-lib/util/date.js';
-
-/**
- * @typedef {Object} Case
- * @property {string} caseId - The unique identifier for the case.
- * @property {string} caseType - The type of the case (e.g., 'W').
- * @property {string} caseProcedure - The procedure for the case (e.g., 'Written').
- * @property {string} allocationBand - The allocation band for the case.
- * @property {string} caseLevel - The level of the case.
- * @property {string} siteAddressPostcode - The postcode of the site address.
- * @property {string} lpaName - The name of the Local Planning Authority (LPA).
- * @property {string} lpaRegion - The region of the Local Planning Authority (LPA).
- * @property {string} caseStatus - The status of the case
- * @property {number} caseAge - The age of the case in weeks.
- * @property {number} linkedCases - The number of linked cases.
- * @property {Date} finalCommentsDate - The date of the final comments.
- */
 /**
  * @param {import('#service').WebService} service
  * @returns {import('express').Handler}
@@ -57,19 +42,24 @@ export function buildViewHome(service) {
 
 		// Convert the raw query string into a nested object
 		const query = qs.parse(parseUrl(req.url).query || '');
-		const { filters } = query;
 
 		const lastSort = readSessionData(req, 'lastRequest', 'sort', 'age', 'persistence');
 
 		const page = req.query.page && (query.sort || 'age') === lastSort ? parseInt(req.query.page) : 1;
 		const limit = req.query.limit ? parseInt(req.query.limit, 10) : 10;
 
-		const { cases, total } = await service.casesClient.getCases(query.sort, page, limit);
+		//parse filters query param as expected Filters type
+		let filters = normalizeFilters(query.filters);
+		//validate filters and return any errors to client
+		const filterErrors = validateFilters(filters);
+		const filterErrorList = Object.values(filterErrors).map((message) => ({ ...message, href: `#` }));
+		//if filters are invalid then apply none
+		if (filterErrorList.length) filters = {};
 
-		const errors = validateFilters(filters);
-		const errorList = Object.values(errors).map((message) => ({ ...message, href: `#` }));
+		const { cases, total } = await service.casesClient.getCases(filters, String(query.sort), page, limit);
 
-		const filteredCases = errorList.length ? cases : filterCases(cases, filters);
+		//const filteredCases = filterErrorList.length ? cases : filterCases(cases, query.filters);
+		const filteredCases = cases;
 
 		const formData = {
 			filters,
@@ -140,8 +130,8 @@ export function buildViewHome(service) {
 			calendarGrid,
 			weekTitle,
 			currentStartDate,
-			errors,
-			errorList,
+			filterErrors,
+			filterErrorList,
 			paginationDetails,
 			specialisms,
 			specialismTypes,
@@ -153,61 +143,6 @@ export function buildViewHome(service) {
 	};
 }
 
-/**
- * @typedef {Object} Filters
- * //any string value can be used as an age filter, we just validate it later
- * @property {string} [minimumAge]
- * @property {string} [maximumAge]
- */
-
-/**
- * @typedef {Partial<Object<keyof Filters, { text: string }>>} ValidationErrors
- */
-
-/**
- *
- * @param {Filters} filters
- * @returns {ValidationErrors}
- */
-export function validateFilters(filters) {
-	/** @type {ValidationErrors} */
-	const errors = {};
-	if (!filters) return errors;
-
-	/** @type {(keyof Filters)[]} */
-	const keysToValidate = ['minimumAge', 'maximumAge'];
-	for (const key of keysToValidate) {
-		const value = filters[key];
-		if (value && (isNaN(+value) || +value < 0 || +value > 500)) {
-			errors[key] = { text: 'Please enter a number between 0 and 500' };
-			filters[key] = '';
-		}
-	}
-	if (filters.maximumAge && filters.minimumAge && !isNaN(+filters.minimumAge) && !isNaN(+filters.maximumAge)) {
-		if (+filters.minimumAge > +filters.maximumAge) {
-			errors.minimumAge = { text: 'The minimum value must be less than or equal to the maximum value.' };
-			filters.minimumAge = '';
-			filters.maximumAge = '';
-		}
-	}
-	return errors;
-}
-
-/**
- *
- * @param {Case[]} cases
- * @param {Filters} filters
- * @returns
- */
-export function filterCases(cases, filters) {
-	if (!filters) return cases;
-	return cases.filter((c) => {
-		//always apply case age filters, using defaults if no filter provided
-		if (!(c.caseAge >= (+filters.minimumAge || 0) && c.caseAge <= (+filters.maximumAge || 999))) return false;
-		return true;
-	});
-}
-
 export function getCaseColor(caseAge) {
 	if (caseAge > 40) return 'd4351c'; // red (41+ weeks)
 	if (caseAge > 20) return 'f47738'; // orange (21-40 weeks)
@@ -216,7 +151,7 @@ export function getCaseColor(caseAge) {
 
 /**
  *
- * @param {Case[]} cases
+ * @param {import('@pins/inspector-programming-lib/data/types.js').Case[]} cases
  * @param {string} sort - The sort criteria, can be 'distance', 'hybrid', or 'age'.
  * @returns
  */

--- a/apps/web/src/app/views/home/controller.js
+++ b/apps/web/src/app/views/home/controller.js
@@ -58,9 +58,6 @@ export function buildViewHome(service) {
 
 		const { cases, total } = await service.casesClient.getCases(filters, String(query.sort), page, limit);
 
-		//const filteredCases = filterErrorList.length ? cases : filterCases(cases, query.filters);
-		const filteredCases = cases;
-
 		const formData = {
 			filters,
 			limit,
@@ -117,7 +114,7 @@ export function buildViewHome(service) {
 			pageHeading: 'Unassigned case list',
 			containerClasses: 'pins-container-wide',
 			title: 'Unassigned case list',
-			cases: filteredCases.map(caseViewModel),
+			cases: cases.map(caseViewModel),
 			inspectors,
 			data: formData,
 			apiKey: service.osMapsApiKey,

--- a/apps/web/src/app/views/home/controller.test.js
+++ b/apps/web/src/app/views/home/controller.test.js
@@ -2,7 +2,6 @@ import { describe, mock, test } from 'node:test';
 import {
 	buildViewHome,
 	caseViewModel,
-	filterCases,
 	getCaseColor,
 	sortCases,
 	handlePagination,
@@ -93,35 +92,6 @@ describe('controller.js', () => {
 				firstName: '',
 				lastName: ''
 			});
-		});
-	});
-	describe('filterCases', () => {
-		test('should return all cases if no filters are applied', () => {
-			const cases = [{ caseAge: 30 }, { caseAge: 10 }, { caseAge: 20 }];
-			const filters = {};
-			const filteredCases = filterCases(cases, filters);
-			assert.strictEqual(filteredCases.length, 3, 'Should return all cases when no filters are applied');
-		});
-		test('should filter cases by minimum age', () => {
-			const cases = [{ caseAge: 30 }, { caseAge: 10 }, { caseAge: 20 }];
-			const filters = { minimumAge: 15 };
-			const filteredCases = filterCases(cases, filters);
-			assert.strictEqual(filteredCases.length, 2, 'Should return cases with age >= 15');
-			assert.deepStrictEqual(filteredCases, [{ caseAge: 30 }, { caseAge: 20 }]);
-		});
-		test('should filter cases by maximum age', () => {
-			const cases = [{ caseAge: 30 }, { caseAge: 10 }, { caseAge: 20 }];
-			const filters = { maximumAge: 20 };
-			const filteredCases = filterCases(cases, filters);
-			assert.strictEqual(filteredCases.length, 2, 'Should return cases with age <= 20');
-			assert.deepStrictEqual(filteredCases, [{ caseAge: 10 }, { caseAge: 20 }]);
-		});
-		test('should filter cases by both minimum and maximum age', () => {
-			const cases = [{ caseAge: 30 }, { caseAge: 10 }, { caseAge: 20 }];
-			const filters = { minimumAge: 15, maximumAge: 25 };
-			const filteredCases = filterCases(cases, filters);
-			assert.strictEqual(filteredCases.length, 1, 'Should return cases with age between 15 and 25');
-			assert.deepStrictEqual(filteredCases, [{ caseAge: 20 }]);
 		});
 	});
 	describe('getCaseColor', () => {

--- a/packages/lib/data/database/cached-cases-client.js
+++ b/packages/lib/data/database/cached-cases-client.js
@@ -1,5 +1,6 @@
 import { CasesClient } from './cases-client.js';
 import { sortCasesByAge } from '../../util/sorting.js';
+import { filterCases } from '../../util/filtering.js';
 
 const CACHE_PREFIX = 'cases_';
 
@@ -41,27 +42,31 @@ export class CachedCasesClient {
 	 * Fetches all cases from cache if there, then applies sort and filtering (TODO) before paginating the resultant cases
 	 * Ideal entry point for fetching cases from the frontend
 	 *
+	 * @param {import('../types.js').Filters} filters
 	 * @param {string} sort - The sort criteria, can be 'distance', 'hybrid', or 'age'.
 	 * @param {number} page
 	 * @param {number} pageSize
 	 * @returns {Promise<{ cases: import('../types').CaseViewModel[], total: number }>}
 	 */
-	async getCases(sort, page, pageSize) {
+	async getCases(filters, sort, page, pageSize) {
 		const allCases = await this.getAllCases();
+
+		//filter
+		const filteredCases = filterCases(allCases, filters);
 
 		//sort
 		let sortedCases;
 		switch (sort) {
 			case 'distance':
 				//WIP
-				sortedCases = allCases;
+				sortedCases = filteredCases;
 				break;
 			case 'hybrid':
 				//WIP
-				sortedCases = allCases;
+				sortedCases = filteredCases;
 				break;
 			default:
-				sortedCases = allCases.sort(sortCasesByAge);
+				sortedCases = filteredCases.sort(sortCasesByAge);
 				break;
 		}
 

--- a/packages/lib/data/types.d.ts
+++ b/packages/lib/data/types.d.ts
@@ -29,3 +29,23 @@ export interface CaseViewModel {
 	specialisms: AppealCaseSpecialism[] | null;
 	specialismList: string | null;
 }
+
+export interface Filters {
+	minimumAge?: string;
+	maximumAge?: string;
+}
+
+export interface Case {
+	caseId: string;
+	caseType: string;
+	caseProcedure: string;
+	allocationBand: string;
+	caseLevel: string;
+	siteAddressPostcode: string;
+	lpaName: string;
+	lpaRegion: string;
+	caseStatus: string;
+	caseAge: number;
+	linkedCases: number;
+	finalCommentsDate: Date;
+}

--- a/packages/lib/util/filtering.js
+++ b/packages/lib/util/filtering.js
@@ -1,0 +1,64 @@
+/**
+ * Normalize query params into Filters object
+ * @param {string | import('qs').ParsedQs | (string | import('qs').ParsedQs)[] | undefined} filters
+ * @returns {import('../data/types.js').Filters}
+ */
+export function normalizeFilters(filters) {
+	if (!filters || typeof filters !== 'object' || Array.isArray(filters)) {
+		return {};
+	}
+
+	return {
+		minimumAge: typeof filters?.minimumAge === 'string' ? filters?.minimumAge : undefined,
+		maximumAge: typeof filters?.maximumAge === 'string' ? filters?.maximumAge : undefined
+	};
+}
+
+/**
+ *
+ * @param {import('../data/types.js').CaseViewModel[]} cases
+ * @param {import('@pins/inspector-programming-lib/data/types.js').Filters} filters
+ * @returns
+ */
+export function filterCases(cases, filters) {
+	if (!(typeof filters === 'object' && filters !== null && !Array.isArray(filters))) return cases;
+
+	return cases.filter((c) => {
+		//always apply case age filters, using defaults if no filter provided
+		if (!(c.caseAge >= +(filters.minimumAge || 0) && c.caseAge <= +(filters.maximumAge || 999))) return false;
+		return true;
+	});
+}
+
+/**
+ * @typedef {Partial<Object<keyof import('@pins/inspector-programming-lib/data/types.js').Filters, { text: string }>>} ValidationErrors
+ */
+
+/**
+ *
+ * @param {import('@pins/inspector-programming-lib/data/types.js').Filters} filters
+ * @returns {ValidationErrors}
+ */
+export function validateFilters(filters) {
+	/** @type {ValidationErrors} */
+	const errors = {};
+	if (!filters) return errors;
+
+	/** @type {(keyof import('@pins/inspector-programming-lib/data/types.js').Filters)[]} */
+	const keysToValidate = ['minimumAge', 'maximumAge'];
+	for (const key of keysToValidate) {
+		const value = filters[key];
+		if (value && (isNaN(+value) || +value < 0 || +value > 500)) {
+			errors[key] = { text: 'Please enter a number between 0 and 500' };
+			filters[key] = '';
+		}
+	}
+	if (filters.maximumAge && filters.minimumAge && !isNaN(+filters.minimumAge) && !isNaN(+filters.maximumAge)) {
+		if (+filters.minimumAge > +filters.maximumAge) {
+			errors.minimumAge = { text: 'The minimum value must be less than or equal to the maximum value.' };
+			filters.minimumAge = '';
+			filters.maximumAge = '';
+		}
+	}
+	return errors;
+}

--- a/packages/lib/util/filtering.js
+++ b/packages/lib/util/filtering.js
@@ -1,5 +1,5 @@
 /**
- * Normalize query params into Filters object
+ * Normalize query params into Filters object for type safety
  * @param {string | import('qs').ParsedQs | (string | import('qs').ParsedQs)[] | undefined} filters
  * @returns {import('../data/types.js').Filters}
  */
@@ -15,17 +15,19 @@ export function normalizeFilters(filters) {
 }
 
 /**
+ * Apply filter object to cases array
  *
  * @param {import('../data/types.js').CaseViewModel[]} cases
  * @param {import('@pins/inspector-programming-lib/data/types.js').Filters} filters
  * @returns
  */
 export function filterCases(cases, filters) {
-	if (!(typeof filters === 'object' && filters !== null && !Array.isArray(filters))) return cases;
+	//sanitise filters object
+	const cleanFilters = !(typeof filters === 'object' && filters !== null && !Array.isArray(filters)) ? {} : filters;
 
 	return cases.filter((c) => {
 		//always apply case age filters, using defaults if no filter provided
-		if (!(c.caseAge >= +(filters.minimumAge || 0) && c.caseAge <= +(filters.maximumAge || 999))) return false;
+		if (!(c.caseAge >= +(cleanFilters.minimumAge || 0) && c.caseAge <= +(cleanFilters.maximumAge || 999))) return false;
 		return true;
 	});
 }
@@ -35,6 +37,7 @@ export function filterCases(cases, filters) {
  */
 
 /**
+ *	Validates filter object and returns any errors back to display to client under their respective filter field
  *
  * @param {import('@pins/inspector-programming-lib/data/types.js').Filters} filters
  * @returns {ValidationErrors}

--- a/packages/lib/util/filtering.test.js
+++ b/packages/lib/util/filtering.test.js
@@ -1,0 +1,104 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { filterCases, validateFilters } from './filtering.js';
+
+describe('filterCases', () => {
+	test('should return all cases if no filters are applied', () => {
+		const cases = [{ caseAge: 30 }, { caseAge: 10 }, { caseAge: 20 }];
+		const filters = {};
+		const filteredCases = filterCases(cases, filters);
+		assert.strictEqual(filteredCases.length, 3, 'Should return all cases when no filters are applied');
+	});
+	test('should filter cases by minimum age', () => {
+		const cases = [{ caseAge: 30 }, { caseAge: 10 }, { caseAge: 20 }];
+		const filters = { minimumAge: 15 };
+		const filteredCases = filterCases(cases, filters);
+		assert.strictEqual(filteredCases.length, 2, 'Should return cases with age >= 15');
+		assert.deepStrictEqual(filteredCases, [{ caseAge: 30 }, { caseAge: 20 }]);
+	});
+	test('should filter cases by maximum age', () => {
+		const cases = [{ caseAge: 30 }, { caseAge: 10 }, { caseAge: 20 }];
+		const filters = { maximumAge: 20 };
+		const filteredCases = filterCases(cases, filters);
+		assert.strictEqual(filteredCases.length, 2, 'Should return cases with age <= 20');
+		assert.deepStrictEqual(filteredCases, [{ caseAge: 10 }, { caseAge: 20 }]);
+	});
+	test('should filter cases by both minimum and maximum age', () => {
+		const cases = [{ caseAge: 30 }, { caseAge: 10 }, { caseAge: 20 }];
+		const filters = { minimumAge: 15, maximumAge: 25 };
+		const filteredCases = filterCases(cases, filters);
+		assert.strictEqual(filteredCases.length, 1, 'Should return cases with age between 15 and 25');
+		assert.deepStrictEqual(filteredCases, [{ caseAge: 20 }]);
+	});
+	test('invalid filter object should not apply filters', () => {
+		const cases = [{ caseAge: 30 }, { caseAge: 10 }, { caseAge: 20 }];
+		const filters = 'invalid';
+		const filteredCases = filterCases(cases, filters);
+		assert.strictEqual(filteredCases.length, 3, 'Should return all cases when invalid filters applied');
+	});
+	test('basic age filtering should be applied even with no filtering applied', () => {
+		const cases = [{ caseAge: 30 }, { caseAge: 10 }, { caseAge: 20 }, { caseAge: -10 }, { caseAge: 1000 }];
+		const filters = {};
+		const filteredCases = filterCases(cases, filters);
+		assert.strictEqual(
+			filteredCases.length,
+			3,
+			'Should filter cases to be within given bounds even without provided filters'
+		);
+	});
+	test('basic age filtering should be applied even with invalid filtering applied', () => {
+		const cases = [{ caseAge: 30 }, { caseAge: 10 }, { caseAge: 20 }, { caseAge: -10 }, { caseAge: 1000 }];
+		const filters = 42;
+		const filteredCases = filterCases(cases, filters);
+		assert.strictEqual(
+			filteredCases.length,
+			3,
+			'Should filter cases to be within given bounds even without provided filters'
+		);
+	});
+});
+describe('validateFilters', () => {
+	test('should return no errors if all filters are valid - age filters', () => {
+		const filters = { minimumAge: 10, maximumAge: 30 };
+		const errors = validateFilters(filters);
+		assert.strictEqual(Object.keys(errors).length, 0, 'should return no errors if all filters are valid - age filters');
+	});
+	test('should return no errors for a valid minimumAge filters alone', () => {
+		const filters = { minimumAge: 10 };
+		const errors = validateFilters(filters);
+		assert.strictEqual(Object.keys(errors).length, 0, 'should return no errors for a valid minimumAge filters alone');
+	});
+	test('should return an error if minimumAge is larger than maximumAge', () => {
+		const filters = { minimumAge: 10, maximumAge: 5 };
+		const errors = validateFilters(filters);
+		assert.strictEqual(Object.keys(errors).length, 1, 'should return one error');
+		assert.ok('minimumAge' in errors, "result should have an 'minimumAge' property");
+		assert.strictEqual(
+			errors.minimumAge.text,
+			'The minimum value must be less than or equal to the maximum value.',
+			'should return "The minimum value must be less than or equal to the maximum value." under minimumAge'
+		);
+	});
+	test('should return an error if an age filter is below 0', () => {
+		const filters = { minimumAge: -1, maximumAge: 5 };
+		const errors = validateFilters(filters);
+		assert.strictEqual(Object.keys(errors).length, 1, 'should return one error');
+		assert.ok('minimumAge' in errors, "result should have an 'minimumAge' property");
+		assert.strictEqual(
+			errors.minimumAge.text,
+			'Please enter a number between 0 and 500',
+			'should return "Please enter a number between 0 and 500" under minimumAge'
+		);
+	});
+	test('should return an error if an age filter is above 500', () => {
+		const filters = { minimumAge: 10, maximumAge: 501 };
+		const errors = validateFilters(filters);
+		assert.strictEqual(Object.keys(errors).length, 1, 'should return one error');
+		assert.ok('maximumAge' in errors, "result should have an 'maximumAge' property");
+		assert.strictEqual(
+			errors.maximumAge.text,
+			'Please enter a number between 0 and 500',
+			'should return "Please enter a number between 0 and 500" under maximumAge'
+		);
+	});
+});


### PR DESCRIPTION
## Describe your changes
Moves case filtering from controller.js into casesClient.getCases to be applied on the whole set of cases pre-pagination. Also moves a lot of filtering functionality to a standalone util file where it probably fits better. Testing included.

## Issue ticket number and link
https://pins-ds.atlassian.net.mcas.ms/jira/software/projects/PPB/boards/373