### PR TITLE
feature/ppb-122-linked-cases-on-unassigned-case-list

### DIFF
--- a/apps/web/src/app/views/home/cases-table.njk
+++ b/apps/web/src/app/views/home/cases-table.njk
@@ -19,7 +19,7 @@
             { text: c.lpaRegion },
             { html: govukTag({text: c.caseStatus }) },
             { html: '<span class="case-border" style="--border-color:#' + c.caseAgeColor + ';">' + c.caseAge + '</span>' },
-            { text: c.linkedCases },
+            { text: c.linkedCaseReferences[0] },
             { text: c.finalCommentsDate }
         ]), caseRows) %}
 {% endfor %}

--- a/packages/database/src/migrations/20250829132547_appeal_case_linked_cases/migration.sql
+++ b/packages/database/src/migrations/20250829132547_appeal_case_linked_cases/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[AppealCase] ADD CONSTRAINT [AppealCase_leadCaseReference_fkey] FOREIGN KEY ([leadCaseReference]) REFERENCES [dbo].[AppealCase]([caseReference]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -55,6 +55,9 @@ model AppealCase {
   linkedCaseStatus  String?
   leadCaseReference String?
 
+  LeadCase   AppealCase?  @relation("LinkedCases", fields: [leadCaseReference], references: [caseReference], onDelete: NoAction, onUpdate: NoAction)
+  ChildCases AppealCase[] @relation("LinkedCases")
+
   appellantCostsAppliedFor Boolean?
   lpaCostsAppliedFor       Boolean?
 

--- a/packages/lib/data/database/cases-client.test.js
+++ b/packages/lib/data/database/cases-client.test.js
@@ -33,7 +33,8 @@ describe('CasesClient', () => {
 					leadCaseReference: null,
 					appellantCostsAppliedFor: null,
 					lpaCostsAppliedFor: null,
-					inspectorId: null
+					inspectorId: null,
+					ChildCases: []
 				},
 				{
 					caseReference: 'ref2',
@@ -59,7 +60,8 @@ describe('CasesClient', () => {
 					leadCaseReference: null,
 					appellantCostsAppliedFor: null,
 					lpaCostsAppliedFor: null,
-					inspectorId: null
+					inspectorId: null,
+					ChildCases: []
 				}
 			];
 
@@ -81,7 +83,7 @@ describe('CasesClient', () => {
 					caseReceivedDate: null,
 					caseStatus: 'lpa_questionnaire',
 					caseType: 'W',
-					linkedCases: 0,
+					linkedCaseReferences: [],
 					lpaName: 'Example Local Planning Authority',
 					lpaRegion: '',
 					siteAddressPostcode: 'SY10 7FA',
@@ -89,7 +91,8 @@ describe('CasesClient', () => {
 					siteAddressLongitude: -3.064346,
 					finalCommentsDate: new Date('2024-10-10T10:26:11.963Z'),
 					specialismList: 'None',
-					specialisms: undefined
+					specialisms: undefined,
+					leadCaseReference: null
 				},
 				{
 					allocationBand: 1,
@@ -105,10 +108,11 @@ describe('CasesClient', () => {
 					siteAddressLongitude: -3.001122,
 					lpaName: 'Other Local Planning Authority',
 					lpaRegion: '',
-					linkedCases: 0,
+					linkedCaseReferences: [],
 					finalCommentsDate: new Date('2024-10-10T10:26:11.963Z'),
 					specialisms: undefined,
-					specialismList: 'None'
+					specialismList: 'None',
+					leadCaseReference: null
 				}
 			]);
 		});
@@ -128,11 +132,12 @@ describe('CasesClient', () => {
 				lpaRegion: '',
 				caseStatus: 'lpa_questionnaire',
 				caseAge: 49,
-				linkedCases: 0,
+				linkedCaseReferences: [],
 				caseReceivedDate: null,
 				finalCommentsDate: new Date('2024-10-10T10:26:11.963Z'),
 				specialisms: undefined,
-				specialismList: 'None'
+				specialismList: 'None',
+				leadCaseReference: null
 			},
 			{
 				caseId: 'ref2',
@@ -147,11 +152,12 @@ describe('CasesClient', () => {
 				lpaRegion: '',
 				caseStatus: 'lpa_questionnaire',
 				caseAge: 49,
-				linkedCases: 0,
+				linkedCaseReferences: [],
 				caseReceivedDate: null,
 				finalCommentsDate: new Date('2024-10-10T10:26:11.963Z'),
 				specialisms: undefined,
-				specialismList: 'None'
+				specialismList: 'None',
+				leadCaseReference: null
 			},
 			{
 				caseId: 'ref3',
@@ -166,11 +172,12 @@ describe('CasesClient', () => {
 				lpaRegion: '',
 				caseStatus: 'lpa_questionnaire',
 				caseAge: 49,
-				linkedCases: 0,
+				linkedCaseReferences: [],
 				caseReceivedDate: null,
 				finalCommentsDate: new Date('2024-10-10T10:26:11.963Z'),
 				specialisms: undefined,
-				specialismList: 'None'
+				specialismList: 'None',
+				leadCaseReference: null
 			},
 			{
 				caseId: 'ref4',
@@ -185,11 +192,12 @@ describe('CasesClient', () => {
 				lpaRegion: '',
 				caseStatus: 'lpa_questionnaire',
 				caseAge: 49,
-				linkedCases: 0,
+				linkedCaseReferences: [],
 				caseReceivedDate: null,
 				finalCommentsDate: new Date('2024-10-10T10:26:11.963Z'),
 				specialisms: undefined,
-				specialismList: 'None'
+				specialismList: 'None',
+				leadCaseReference: null
 			},
 			{
 				caseId: 'ref5',
@@ -204,11 +212,12 @@ describe('CasesClient', () => {
 				lpaRegion: '',
 				caseStatus: 'lpa_questionnaire',
 				caseAge: 49,
-				linkedCases: 0,
+				linkedCaseReferences: [],
 				caseReceivedDate: null,
 				finalCommentsDate: new Date('2024-10-10T10:26:11.963Z'),
 				specialisms: undefined,
-				specialismList: 'None'
+				specialismList: 'None',
+				leadCaseReference: null
 			}
 		];
 

--- a/packages/lib/data/types.d.ts
+++ b/packages/lib/data/types.d.ts
@@ -25,11 +25,12 @@ export interface CaseViewModel {
 	caseStatus: string | null;
 	caseAge: number;
 	caseAgeColor?: string;
-	linkedCases: number;
+	linkedCaseReferences: string[];
 	caseReceivedDate: Date | null;
 	finalCommentsDate: Date | string;
 	specialisms: AppealCaseSpecialism[] | null;
 	specialismList: string | null;
+	leadCaseReference: string | null;
 }
 
 export interface Filters {


### PR DESCRIPTION
## Describe your changes
- Update the unassigned case list so the Linked cases reference field displays (instead of a count). If no child cases exist, the field remains blank.
- Updated the AppealCase model and seeding. Not fully confident this approach is correct, so I’m happy to adjust based on feedback.

## Issue ticket number and link
https://pins-ds.atlassian.net/jira/software/projects/PPB/boards/373?jql=assignee%20%3D%20712020%3Af7b1896a-6340-43b8-ac80-7b8c8a31ddfe&selectedIssue=PPB-122