### PR TITLE
chore/ppb 109 create calendar event timings table

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "commitlint": "commitlint --from=$(git cherry origin/main | head -n 1 | cut -c 3-)",
     "db-migrate-dev": "npm run migrate-dev --workspace @pins/inspector-programming-database",
+    "db-reset-dev": "npm run reset-dev --workspace @pins/inspector-programming-database",
     "db-migrate-prod": "npm run migrate-prod --workspace @pins/inspector-programming-database",
     "db-generate": "npm run generate --workspace @pins/inspector-programming-database",
     "db-seed": "npm run seed --workspace @pins/inspector-programming-database",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "migrate-dev": "npx prisma migrate dev",
+    "reset-dev": "npx prisma migrate reset",
     "migrate-prod": "npx prisma migrate deploy",
     "generate": "npx prisma generate",
     "seed": "npx prisma db seed"

--- a/packages/database/src/migrations/20250904140626_create_calendar_events_timings_table/migration.sql
+++ b/packages/database/src/migrations/20250904140626_create_calendar_events_timings_table/migration.sql
@@ -1,0 +1,40 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- CreateTable
+CREATE TABLE [dbo].[CalendarEventTiming] (
+    [id] UNIQUEIDENTIFIER NOT NULL CONSTRAINT [CalendarEventTiming_id_df] DEFAULT newid(),
+    [prepTime] INT NOT NULL,
+    [siteVisitTime] INT NOT NULL,
+    [reportTime] INT NOT NULL,
+    [costsTime] INT NOT NULL,
+    CONSTRAINT [CalendarEventTiming_pkey] PRIMARY KEY CLUSTERED ([id])
+);
+
+-- CreateTable
+CREATE TABLE [dbo].[CalendarEventTimingRule] (
+    [id] UNIQUEIDENTIFIER NOT NULL CONSTRAINT [CalendarEventTimingRule_id_df] DEFAULT newid(),
+    [calendarEventTimingId] UNIQUEIDENTIFIER NOT NULL,
+    [caseType] NVARCHAR(1000) NOT NULL,
+    [caseProcedure] NVARCHAR(1000) NOT NULL,
+    [allocationLevel] NVARCHAR(1000) NOT NULL,
+    CONSTRAINT [CalendarEventTimingRule_pkey] PRIMARY KEY CLUSTERED ([id]),
+    CONSTRAINT [CalendarEventTimingRule_caseType_caseProcedure_allocationLevel_key] UNIQUE NONCLUSTERED ([caseType],[caseProcedure],[allocationLevel])
+);
+
+-- AddForeignKey
+ALTER TABLE [dbo].[CalendarEventTimingRule] ADD CONSTRAINT [CalendarEventTimingRule_calendarEventTimingId_fkey] FOREIGN KEY ([calendarEventTimingId]) REFERENCES [dbo].[CalendarEventTiming]([id]) ON DELETE CASCADE ON UPDATE CASCADE;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -132,3 +132,24 @@ model InspectorSpecialism {
 
   Inspector Inspector @relation(fields: [inspectorId], references: [id], onDelete: Cascade)
 }
+
+model CalendarEventTiming {
+  id                       String                    @id @default(dbgenerated("newid()")) @db.UniqueIdentifier
+  CalendarEventTimingRules CalendarEventTimingRule[]
+  prepTime                 Int
+  siteVisitTime            Int
+  reportTime               Int
+  costsTime                Int
+}
+
+model CalendarEventTimingRule {
+  id                    String @id @default(dbgenerated("newid()")) @db.UniqueIdentifier
+  calendarEventTimingId String @db.UniqueIdentifier
+  caseType              String
+  caseProcedure         String
+  allocationLevel       String
+
+  CalendarEventTiming CalendarEventTiming @relation(fields: [calendarEventTimingId], references: [id], onDelete: Cascade)
+
+  @@unique([caseType, caseProcedure, allocationLevel])
+}

--- a/packages/database/src/seed/data-static-guids.js
+++ b/packages/database/src/seed/data-static-guids.js
@@ -1,0 +1,7 @@
+export const calendarEventTimingIds = [
+	'746d4006-82f6-4631-875f-75dbf66c3271',
+	'b8db4d4e-ba13-4378-ba1a-e6fc0629a023',
+	'e2d13461-64ac-4ab4-a4f5-4b7cd9bc5220',
+	'd4f53ef1-ab2d-4e65-8f9c-97eaf4dce20b',
+	'09500a7a-e790-4c42-b89d-c80b849783d6'
+];

--- a/packages/database/src/seed/data-static.js
+++ b/packages/database/src/seed/data-static.js
@@ -1,8 +1,351 @@
+import { APPEAL_ALLOCATION_LEVEL, APPEAL_CASE_PROCEDURE, APPEAL_CASE_TYPE } from '@planning-inspectorate/data-model';
+import { calendarEventTimingIds } from './data-static-guids.js';
+
+/**
+ * @type {import('@pins/inspector-programming-database/src/client').Prisma.CalendarEventTimingCreateInput[]}
+ */
+const calendarEventTimings = [
+	{
+		id: calendarEventTimingIds[0],
+		CalendarEventTimingRules: {
+			connectOrCreate: [
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.D, //householder
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.F
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.D,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.F
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.D, //householder
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.G
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.D,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.G
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.D, //householder
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.H
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.D,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.H
+					}
+				}
+			]
+		},
+		prepTime: 0,
+		siteVisitTime: 2,
+		reportTime: 6,
+		costsTime: 2
+	},
+	{
+		id: calendarEventTimingIds[1],
+		CalendarEventTimingRules: {
+			connectOrCreate: [
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.D, //householder
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.A
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.D,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.A
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.D, //householder
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.B
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.D,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.B
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.D, //householder
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.C
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.D,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.C
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.D, //householder
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.D
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.D,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.D
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.D, //householder
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.E
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.D,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.E
+					}
+				}
+			]
+		},
+		prepTime: 0,
+		siteVisitTime: 2,
+		reportTime: 10,
+		costsTime: 2
+	},
+	{
+		id: calendarEventTimingIds[2],
+		CalendarEventTimingRules: {
+			connectOrCreate: [
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.H, //advertisement
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.H
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.H,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.H
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.ZA, //CAS Adverts
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.H
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.ZA,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.H
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.ZP, //CAS Planning
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.H
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.ZP,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.H
+					}
+				}
+			]
+		},
+		prepTime: 2,
+		siteVisitTime: 2,
+		reportTime: 4,
+		costsTime: 2
+	},
+	{
+		id: calendarEventTimingIds[3],
+		CalendarEventTimingRules: {
+			connectOrCreate: [
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.W, //S78 / Planning
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.F
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.W,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.F
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.W, //S78 / Planning
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.G
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.W,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.G
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.W, //S78 / Planning
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.H
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.W,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.H
+					}
+				}
+			]
+		},
+		prepTime: 2,
+		siteVisitTime: 2,
+		reportTime: 8,
+		costsTime: 4
+	},
+	{
+		id: calendarEventTimingIds[4],
+		CalendarEventTimingRules: {
+			connectOrCreate: [
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.W, //S74 / Planning
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.A
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.W,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.A
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.W, //S74 / Planning
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.B
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.W,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.B
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.W, //S74 / Planning
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.C
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.W,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.C
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.W, //S74 / Planning
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.D
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.W,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.D
+					}
+				},
+				{
+					where: {
+						caseType_caseProcedure_allocationLevel: {
+							caseType: APPEAL_CASE_TYPE.W, //S74 / Planning
+							caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+							allocationLevel: APPEAL_ALLOCATION_LEVEL.E
+						}
+					},
+					create: {
+						caseType: APPEAL_CASE_TYPE.W,
+						caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN,
+						allocationLevel: APPEAL_ALLOCATION_LEVEL.E
+					}
+				}
+			]
+		},
+		prepTime: 2,
+		siteVisitTime: 2,
+		reportTime: 12,
+		costsTime: 4
+	}
+];
+
 /**
  * @param {import('@pins/inspector-programming-database/src/client').PrismaClient} dbClient
  */
 export async function seedStaticData(dbClient) {
-	// TODO: add static seed data
-	await dbClient.$queryRaw`SELECT 1`;
+	await seedCalendarEventTimings(dbClient);
 	console.log('static data seed complete');
+}
+
+/**
+ * @param {import('@pins/inspector-programming-database/src/client').PrismaClient} dbClient
+ */
+async function seedCalendarEventTimings(dbClient) {
+	console.log('seeding', calendarEventTimings.length, 'calendar event timing rules');
+	for (const timing of calendarEventTimings) {
+		await dbClient.calendarEventTiming.upsert({
+			where: { id: timing.id },
+			create: timing,
+			update: timing
+		});
+	}
 }


### PR DESCRIPTION
## Describe your changes
I've created a migration to generate the CalendarEventTiming table in our prisma db, where each record stores a 'rule' and the length of time (in hours) for each stage of the appeals process associated with those rules.

The rules are stored in arrays of other properties, so we can enforce a rule for multiple properties or we can enforce the rule for all properties by leaving the array empty perhaps.

I have seeded in these rules too, but please check that we are storing the correct things for the specialisms, procedures and allocation levels as we will be comparing these!

Also I added a few commands to our package.json that I think may come in handy when developing db migrations.

## Issue ticket number and link
https://pins-ds.atlassian.net.mcas.ms/browse/PPB-109

Appeals Case Types Lookup: https://github.com.mcas.ms/Planning-Inspectorate/inspector-programming/blob/b065d245e95c45134a4220dbb61aea1f8e3fcb04/apps/web/src/app/specialism/specialism.js#L37