### PR TITLE
fix/ppb-149-prevent-all-filter-selection

### DIFF
--- a/apps/web/src/app/views/home/view.njk
+++ b/apps/web/src/app/views/home/view.njk
@@ -16,6 +16,10 @@
 
 {% from "views/home/map/map.njk" import osMap %}
 
+{% from "views/macros/compile-query-fields.njk" import compileSortPaginationQueryFields %}
+{% from "views/macros/compile-query-fields.njk" import compileFilterQueryFields %}
+
+
 {% block pageContent %}
 <div class="filter-container">
     <div class="app-filter">
@@ -216,10 +220,9 @@
                         classes: "custom-filter-dropdown",
                         open: true
                     }) }}
+                    {{ compileSortPaginationQueryFields(filters) }}
                     <input type="hidden" name="inspectorId" value="{{ filters.query.inspectorId }}">
-                    <input type="hidden" name="limit" value="{{ filters.query.limit }}">
                     <input type="hidden" name="page" value="{{ filters.query.page }}">
-                    <input type="hidden" name="sort" value="{{ filters.query.sort }}">
                 </form>
             </div>
         </div>
@@ -256,8 +259,8 @@
                                 </a>{% if not loop.last %} | {% endif %}
                             {% endfor %}
                         </div>
-                <input type="hidden" name="sort" value="{{ filters.query.sort }}">
-                <input type="hidden" name="limit" value="{{ filters.query.limit }}">
+                {{ compileFilterQueryFields(filters) }}
+                {{ compileSortPaginationQueryFields(filters)}}
                 <input type="hidden" name="inspectorId" value="{{ filters.query.inspectorId }}">
                 <input type="hidden" name="page" value="{{ filters.query.page }}">
             </form>
@@ -389,16 +392,6 @@
                 const sortPaginationForm = document.getElementById('sort-pagination-form');
                 const filterForm = document.getElementById('filter-form');
                 if (!sortPaginationForm || !filterForm) return;
-
-                // Copy inputs from the filter form whose name attrs start with 'filters[' into sort form
-                const filterInputs = filterForm.querySelectorAll('input[name^="filters["]');
-                filterInputs.forEach(input => {
-                    const clone = document.createElement('input');
-                    clone.type = 'hidden';
-                    clone.name = input.name;
-                    clone.value = input.value;
-                    sortPaginationForm.appendChild(clone);
-                });
 
                 if(e.target?.dataset?.sort){
                     const sortInput = sortPaginationForm.querySelector('input[name="sort"]');

--- a/apps/web/src/app/views/macros/compile-query-fields.njk
+++ b/apps/web/src/app/views/macros/compile-query-fields.njk
@@ -1,0 +1,26 @@
+{% macro compileFilterQueryFields(filters) %}
+  {% for key, value in filters.query.case %}
+    {% if value is defined and value != "" %}
+      {# Normalize single string to array for iteration #}
+      {% set val = value %}
+      {% if val is string %}
+        {% set val = [val] %}
+      {% endif %}
+
+      {% for v in val %}
+        <input type="hidden" name="filters[{{ key }}]" value="{{ v }}">
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}
+
+{% macro compileSortPaginationQueryFields(filters) %}
+  {# Preserve other top-level params #}
+  {% if filters.query.sort %}
+    <input type="hidden" name="sort" value="{{ filters.query.sort }}">
+  {% endif %}
+  {% if filters.query.limit %}
+    <input type="hidden" name="limit" value="{{ filters.query.limit }}">
+  {% endif %}
+{% endmacro %}
+


### PR DESCRIPTION
## Describe your changes
Moves some form compilation into macros for improved modularity, ensuring all fields are collected in a better way for our controller to handle. This should stop the bug mentioned in the ticket as well as enable us to persist our filters after changing sort or pagination limit

## Issue ticket number and link
https://pins-ds.atlassian.net.mcas.ms/jira/software/projects/PPB/boards/373?selectedIssue=PPB-149