### PR TITLE
task/ppb 170 separate entra and database inspector logic

### DIFF
--- a/apps/web/src/app/config-types.d.ts
+++ b/apps/web/src/app/config-types.d.ts
@@ -23,6 +23,9 @@ interface Config extends BaseConfig {
 	cases: {
 		casesCacheTtl: number;
 	};
+	inspectors: {
+		inspectorsCacheTtl: number;
+	};
 	entra: {
 		// group cache ttl in minutes
 		cacheTtl: number;

--- a/apps/web/src/app/config.js
+++ b/apps/web/src/app/config.js
@@ -42,6 +42,7 @@ export function loadConfig() {
 		AZURE_TENANT_ID,
 		CACHE_CONTROL_MAX_AGE,
 		CASES_CACHE_TTL,
+		INSPECTORS_CACHE_TTL,
 		ENTRA_GROUP_CACHE_TTL,
 		ENTRA_GROUP_ID_INSPECTORS,
 		ENTRA_GROUP_ID_NATIONAL_TEAM,
@@ -125,6 +126,9 @@ export function loadConfig() {
 		},
 		cases: {
 			casesCacheTtl: parseInt(CASES_CACHE_TTL || 15)
+		},
+		inspectors: {
+			inspectorsCacheTtl: parseInt(INSPECTORS_CACHE_TTL || 15)
 		},
 		database: {
 			datasourceUrl: SQL_CONNECTION_STRING

--- a/apps/web/src/app/inspector/inspector.js
+++ b/apps/web/src/app/inspector/inspector.js
@@ -81,10 +81,8 @@ export async function getInspectorList(service, authSession) {
 	}
 
 	//validate retrieved inspectors also exist in Entra group
-	//const dbInspectors = await service.inspectorClient.getAllInspectors();
-	//console.info(dbInspectors[0]);
-	//console.info(inspectors[0]);
-	//inspectors.filter((i) => )
+	const dbInspectorIds = ((await service.inspectorClient.getAllInspectors()) || []).map((i) => i.id);
+	inspectors = inspectors.filter((i) => dbInspectorIds.includes(i.id));
 
 	return inspectors;
 }

--- a/apps/web/src/app/inspector/inspector.js
+++ b/apps/web/src/app/inspector/inspector.js
@@ -1,24 +1,6 @@
 import { checkAccountGroupAccess, getAccountId } from '#util/account.js';
 
 /**
- *
- * @param {import('@pins/inspector-programming-database/src/client').PrismaClient} db
- * @param {string|undefined} entraId
- * @returns {Promise<import('@pins/inspector-programming-database/src/client').Inspector|null>}
- */
-export async function getInspectorDetails(db, entraId) {
-	if (!entraId) {
-		return null;
-	}
-	return db.inspector.findFirst({
-		where: { entraId },
-		include: {
-			Specialisms: true
-		}
-	});
-}
-
-/**
  * @param {import("@pins/inspector-programming-lib/graph/types").InitEntraClient} initEntraClient
  * @param {import("@pins/inspector-programming-lib/graph/types").AuthSession} authSession
  * @param {import('pino').Logger} logger

--- a/apps/web/src/app/inspector/inspector.js
+++ b/apps/web/src/app/inspector/inspector.js
@@ -45,6 +45,8 @@ export async function getInspectorById(initEntraClient, authSession, logger, gro
 }
 
 /**
+ * Frontend-facing
+ * Fetches formatted and sorted list of inspectors from Entra - validated that they also exist in our local db too
  * @param {import('#service').WebService} service
  * @param {import("../auth/session.service").SessionWithAuth} authSession
  * @returns {Promise<import("@pins/inspector-programming-lib/data/types").InspectorViewModel[]>}
@@ -77,6 +79,12 @@ export async function getInspectorList(service, authSession) {
 			inspectors.push(inspector);
 		}
 	}
+
+	//validate retrieved inspectors also exist in Entra group
+	//const dbInspectors = await service.inspectorClient.getAllInspectors();
+	//console.info(dbInspectors[0]);
+	//console.info(inspectors[0]);
+	//inspectors.filter((i) => )
 
 	return inspectors;
 }

--- a/apps/web/src/app/inspector/inspector.test.js
+++ b/apps/web/src/app/inspector/inspector.test.js
@@ -1,12 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import { strict as assert } from 'node:assert';
-import {
-	getInspectorById,
-	fetchInspectorList,
-	getSortedInspectorList,
-	getInspectorList,
-	getInspectorDetails
-} from './inspector.js';
+import { getInspectorById, fetchInspectorList, getSortedInspectorList, getInspectorList } from './inspector.js';
 
 const groupId = 'groupId';
 const mockSession = {};
@@ -446,35 +440,5 @@ describe('inspectors', () => {
 		mockEntraClient.listAllGroupMembers.mock.mockImplementationOnce(() => groupMemberList);
 		const inspectorList = await getInspectorList(mockService, mockSessionWithAccount);
 		assert.deepStrictEqual(inspectorList, expectedInspectorList);
-	});
-});
-
-describe('getInspectorDetails', () => {
-	it('should return null if no inspectorId is provided', async () => {
-		const mockDb = {
-			inspectors: {
-				findUnique: mock.fn()
-			}
-		};
-		const result = await getInspectorDetails(mockDb, undefined);
-		assert.equal(result, null);
-	});
-	it('should return inspector if inspectorId is provided', async () => {
-		const mockInspector = {
-			id: '1',
-			firstName: 'John',
-			lastName: 'Doe'
-		};
-		const mockDb = {
-			inspector: {
-				findFirst: mock.fn(() => mockInspector)
-			}
-		};
-		const result = await getInspectorDetails(mockDb, 'entra-id-1');
-		assert.equal(result, mockInspector);
-		assert.equal(mockDb.inspector.findFirst.mock.callCount(), 1);
-		const args = mockDb.inspector.findFirst.mock.calls[0].arguments[0];
-		assert.deepEqual(args.where?.entraId, 'entra-id-1');
-		assert.deepEqual(args?.include, { Specialisms: true });
 	});
 });

--- a/apps/web/src/app/inspector/inspector.test.js
+++ b/apps/web/src/app/inspector/inspector.test.js
@@ -17,6 +17,9 @@ mockInitEntraClient.mock.mockImplementation(() => mockEntraClient);
 
 const mockService = {
 	entraClient: mockInitEntraClient,
+	inspectorClient: {
+		getAllInspectors: mock.fn()
+	},
 	logger: mockLogger,
 	entraGroupIds: {
 		teamLeads: '0',
@@ -335,7 +338,7 @@ describe('inspectors', () => {
 				}
 			}
 		};
-
+		mockService.inspectorClient.getAllInspectors.mock.mockImplementationOnce(() => expectedInspectorList);
 		mockEntraClient.listAllGroupMembers.mock.mockImplementationOnce(() => groupMemberList);
 		const inspectorList = await getInspectorList(mockService, mockSessionWithAccount);
 		assert.deepStrictEqual(inspectorList, expectedInspectorList);
@@ -392,6 +395,7 @@ describe('inspectors', () => {
 			}
 		};
 
+		mockService.inspectorClient.getAllInspectors.mock.mockImplementationOnce(() => expectedInspectorList);
 		mockEntraClient.listAllGroupMembers.mock.mockImplementationOnce(() => groupMemberList);
 		const inspectorList = await getInspectorList(mockService, mockSessionWithAccount);
 		assert.deepStrictEqual(inspectorList, expectedInspectorList);
@@ -437,6 +441,7 @@ describe('inspectors', () => {
 			}
 		};
 
+		mockService.inspectorClient.getAllInspectors.mock.mockImplementationOnce(() => expectedInspectorList);
 		mockEntraClient.listAllGroupMembers.mock.mockImplementationOnce(() => groupMemberList);
 		const inspectorList = await getInspectorList(mockService, mockSessionWithAccount);
 		assert.deepStrictEqual(inspectorList, expectedInspectorList);

--- a/apps/web/src/app/service.js
+++ b/apps/web/src/app/service.js
@@ -1,11 +1,11 @@
 import { BaseService } from '@pins/inspector-programming-lib/app/base-service.js';
 import { buildInitEntraClient } from '@pins/inspector-programming-lib/graph/cached-entra-client.js';
 import { buildInitCasesClient } from '@pins/inspector-programming-lib/data/database/cached-cases-client.js';
+import { buildInitInspectorClient } from '@pins/inspector-programming-lib/data/database/cached-inspector-client.js';
 import { MapCache } from '@pins/inspector-programming-lib/util/map-cache.js';
 import { ApiService } from '#api-service';
 import { OsApiClient } from '@pins/inspector-programming-lib/os/os-api-client.js';
 import { initGovNotify } from '@pins/inspector-programming-lib/emails/index.js';
-import { InspectorClient } from '@pins/inspector-programming-lib/data/database/inspector-client.js';
 
 /**
  * This class encapsulates all the services and clients for the application
@@ -29,7 +29,8 @@ export class WebService extends BaseService {
 		const casesCache = new MapCache(config.cases.casesCacheTtl);
 		this.casesClient = buildInitCasesClient(this.dbClient, casesCache);
 
-		this.inspectorClient = new InspectorClient(this.dbClient);
+		const inspectorCache = new MapCache(config.inspectors.inspectorsCacheTtl);
+		this.inspectorClient = buildInitInspectorClient(this.dbClient, inspectorCache);
 
 		const entraGroupCache = new MapCache(config.entra.cacheTtl);
 		this.entraClient = buildInitEntraClient(!config.auth.disabled, entraGroupCache);

--- a/apps/web/src/app/service.js
+++ b/apps/web/src/app/service.js
@@ -5,6 +5,7 @@ import { MapCache } from '@pins/inspector-programming-lib/util/map-cache.js';
 import { ApiService } from '#api-service';
 import { OsApiClient } from '@pins/inspector-programming-lib/os/os-api-client.js';
 import { initGovNotify } from '@pins/inspector-programming-lib/emails/index.js';
+import { InspectorClient } from '@pins/inspector-programming-lib/data/database/inspector-client.js';
 
 /**
  * This class encapsulates all the services and clients for the application
@@ -27,6 +28,8 @@ export class WebService extends BaseService {
 
 		const casesCache = new MapCache(config.cases.casesCacheTtl);
 		this.casesClient = buildInitCasesClient(this.dbClient, casesCache);
+
+		this.inspectorClient = new InspectorClient(this.dbClient);
 
 		const entraGroupCache = new MapCache(config.entra.cacheTtl);
 		this.entraClient = buildInitEntraClient(!config.auth.disabled, entraGroupCache);

--- a/apps/web/src/app/views/case/controller.js
+++ b/apps/web/src/app/views/case/controller.js
@@ -1,6 +1,5 @@
 import { getCaseDetails } from '../../case/case.js';
 import { toInspectorViewModel } from '../home/view-model.js';
-import { getInspectorDetails } from '../../inspector/inspector.js';
 import { caseToViewModel } from './view-model.js';
 
 /**
@@ -11,7 +10,7 @@ export function buildViewCase(service) {
 	return async (req, res) => {
 		/** @type {string} */
 		const inspectorId = String(req.query.inspectorId);
-		const inspectorData = await getInspectorDetails(service.db, inspectorId);
+		const inspectorData = await service.inspectorClient.getInspectorDetails(inspectorId);
 
 		/** @type {string} */
 		const caseId = String(req.params.caseId);

--- a/apps/web/src/app/views/case/controller.test.js
+++ b/apps/web/src/app/views/case/controller.test.js
@@ -45,9 +45,6 @@ describe('buildViewCase', () => {
 
 		const service = {
 			db: {
-				inspector: {
-					findFirst: mock.fn(async ({ where }) => (where.entraId === inspectorData.id ? inspectorData : null))
-				},
 				appealCase: {
 					findUnique: mock.fn(async ({ where }) => (where.caseReference === caseData.caseReference ? caseData : null))
 				}
@@ -55,6 +52,9 @@ describe('buildViewCase', () => {
 			osMapsApiKey: 'test-api-key',
 			casesClient: {
 				caseToViewModel: mock.fn(() => caseViewModel)
+			},
+			inspectorClient: {
+				getInspectorDetails: mock.fn(async (entraId) => (entraId === inspectorData.id ? inspectorData : null))
 			}
 		};
 
@@ -90,18 +90,15 @@ describe('buildViewCase', () => {
 			caseAgeColor: '00703c'
 		});
 
-		assert.strictEqual(service.db.inspector.findFirst.mock.calls.length, 1);
 		assert.strictEqual(service.db.appealCase.findUnique.mock.calls.length, 1);
 		assert.strictEqual(service.casesClient.caseToViewModel.mock.calls.length, 1);
+		assert.strictEqual(service.inspectorClient.getInspectorDetails.mock.calls.length, 1);
 		assert.deepStrictEqual(service.casesClient.caseToViewModel.mock.calls[0].arguments[0], caseData);
 	});
 
 	test('handles missing inspectorId and caseId gracefully', async () => {
 		const service = {
 			db: {
-				inspector: {
-					findFirst: mock.fn(async () => null)
-				},
 				appealCase: {
 					findUnique: mock.fn(async () => null)
 				}
@@ -109,6 +106,9 @@ describe('buildViewCase', () => {
 			osMapsApiKey: 'test-api-key',
 			casesClient: {
 				caseToViewModel: mock.fn(() => null)
+			},
+			inspectorClient: {
+				getInspectorDetails: mock.fn(async () => null)
 			}
 		};
 
@@ -130,8 +130,8 @@ describe('buildViewCase', () => {
 		assert.strictEqual(renderedModel.inspectorPin, toInspectorViewModel(null));
 		assert.strictEqual(renderedModel.caseData, null);
 
-		assert.strictEqual(service.db.inspector.findFirst.mock.calls.length, 1);
 		assert.strictEqual(service.db.appealCase.findUnique.mock.calls.length, 1);
+		assert.strictEqual(service.inspectorClient.getInspectorDetails.mock.calls.length, 1);
 		assert.strictEqual(service.casesClient.caseToViewModel.mock.calls.length, 1);
 		assert.strictEqual(service.casesClient.caseToViewModel.mock.calls[0].arguments[0], null);
 	});

--- a/apps/web/src/app/views/home/controller.js
+++ b/apps/web/src/app/views/home/controller.js
@@ -1,4 +1,4 @@
-import { getInspectorDetails, getInspectorList } from '../../inspector/inspector.js';
+import { getInspectorList } from '../../inspector/inspector.js';
 import { allocationLevels, caseTypes, specialisms } from '../../specialism/specialism.js';
 import {
 	getNextWeekStartDate,
@@ -21,7 +21,7 @@ export function buildViewHome(service) {
 		const inspectors = await getInspectorList(service, req.session);
 		/** @type {import('@pins/inspector-programming-lib/data/types.js').InspectorViewModel | undefined} */
 		const selectedInspector = inspectors.find((i) => req.query.inspectorId === i.id);
-		const selectedInspectorDetails = await getInspectorDetails(service.db, selectedInspector?.id);
+		const selectedInspectorDetails = await service.inspectorClient.getInspectorDetails(selectedInspector?.id);
 
 		const lastSort = readSessionData(req, 'lastRequest', 'sort', 'age', 'persistence');
 		const filterQuery = filtersQueryViewModel(req.query, lastSort);

--- a/apps/web/src/app/views/home/controller.test.js
+++ b/apps/web/src/app/views/home/controller.test.js
@@ -24,10 +24,8 @@ describe('controller.js', () => {
 					getAllCases: mock.fn(() => []),
 					getCases: mock.fn(() => ({ cases: [], total: 0 }))
 				},
-				db: {
-					inspector: {
-						findFirst: mock.fn()
-					}
+				inspectorClient: {
+					getInspectorDetails: mock.fn()
 				}
 			};
 		};
@@ -65,7 +63,7 @@ describe('controller.js', () => {
 				latitude: 51.4508591,
 				Specialisms: []
 			};
-			service.db.inspector.findFirst.mock.mockImplementationOnce(() => inspectorData);
+			service.inspectorClient.getInspectorDetails.mock.mockImplementationOnce(() => inspectorData);
 			const req = {
 				url: '/?inspectorId=inspector-id',
 				query: { inspectorId: 'inspector-id' },
@@ -78,7 +76,7 @@ describe('controller.js', () => {
 			assert.deepStrictEqual(service.casesClient.getCases.mock.calls[0].arguments[0], {
 				inspectorCoordinates: { lat: 51.4508591, lng: -2.5828931 }
 			});
-			assert.strictEqual(service.db.inspector.findFirst.mock.callCount(), 1);
+			assert.strictEqual(service.inspectorClient.getInspectorDetails.mock.callCount(), 1);
 			assert.strictEqual(res.render.mock.callCount(), 1);
 			const args = res.render.mock.calls[0].arguments[1];
 			assert.strictEqual(args.appeals?.cases?.length, 10);
@@ -134,7 +132,7 @@ describe('controller.js', () => {
 			await controller(req, res);
 			assert.strictEqual(service.casesClient.getCases.mock.callCount(), 1);
 			assert.deepStrictEqual(service.casesClient.getCases.mock.calls[0].arguments[0], {});
-			assert.strictEqual(service.db.inspector.findFirst.mock.callCount(), 1);
+			assert.strictEqual(service.inspectorClient.getInspectorDetails.mock.callCount(), 1);
 			assert.strictEqual(res.render.mock.callCount(), 1);
 			const args = res.render.mock.calls[0].arguments[1];
 			assert.strictEqual(args.appeals?.cases?.length, 10);

--- a/apps/web/src/app/views/home/controller.test.js
+++ b/apps/web/src/app/views/home/controller.test.js
@@ -25,7 +25,8 @@ describe('controller.js', () => {
 					getCases: mock.fn(() => ({ cases: [], total: 0 }))
 				},
 				inspectorClient: {
-					getInspectorDetails: mock.fn()
+					getInspectorDetails: mock.fn(),
+					getAllInspectors: mock.fn()
 				}
 			};
 		};

--- a/packages/lib/data/database/cached-inspector-client.js
+++ b/packages/lib/data/database/cached-inspector-client.js
@@ -1,0 +1,61 @@
+import { InspectorClient } from './inspector-client.js';
+
+const CACHE_PREFIX = 'inspectors_';
+
+/**
+ * @typedef {import('../../util/map-cache.js').MapCache} MapCache
+ */
+
+/**
+ * @param {import('@pins/inspector-programming-database/src/client').PrismaClient} dbClient
+ * @param {MapCache} cache
+ * @returns {CachedInspectorClient}
+ */
+export function buildInitInspectorClient(dbClient, cache) {
+	const inspectorClient = new InspectorClient(dbClient);
+	return new CachedInspectorClient(inspectorClient, cache);
+}
+
+/**
+ * Wraps the CasesClient with a cache
+ */
+export class CachedInspectorClient {
+	/** @type {InspectorClient} */
+	#client;
+	/** @type {MapCache} */
+	#cache;
+
+	/**
+	 *
+	 * @param {InspectorClient} client
+	 * @param {MapCache} cache
+	 */
+	constructor(client, cache) {
+		this.#client = client;
+		this.#cache = cache;
+	}
+
+	/**
+	 *
+	 * @param {string|undefined} entraId
+	 * @returns {Promise<import('@pins/inspector-programming-database/src/client').Inspector|null>}
+	 */
+	async getInspectorDetails(entraId) {
+		return this.#client.getInspectorDetails(entraId);
+	}
+
+	/**
+	 *
+	 * @returns {Promise<import('@pins/inspector-programming-database/src/client').Inspector[]>}
+	 */
+	async getAllInspectors() {
+		const key = CACHE_PREFIX + 'getAllInspectors';
+		let inspectors = this.#cache.get(key);
+		if (inspectors) {
+			return inspectors;
+		}
+		inspectors = await this.#client.getAllInspectors();
+		this.#cache.set(key, inspectors);
+		return inspectors;
+	}
+}

--- a/packages/lib/data/database/cached-inspector-client.test.js
+++ b/packages/lib/data/database/cached-inspector-client.test.js
@@ -1,0 +1,42 @@
+import { describe, it, mock } from 'node:test';
+import { buildInitInspectorClient, CachedInspectorClient } from './cached-inspector-client.js';
+import assert from 'node:assert';
+
+describe('cached-inspector-client', () => {
+	describe('buildInitCasesClient', () => {
+		const mockClient = {};
+		const mockCache = {
+			get: mock.fn(() => [1, 2, 3])
+		};
+
+		it('should return a CachedInspectorClient', () => {
+			const initEntraClient = buildInitInspectorClient(mockClient, mockCache);
+			assert.strictEqual(initEntraClient instanceof CachedInspectorClient, true);
+		});
+	});
+	describe('CachedInspectorClient', () => {
+		it('should return cached entry if present', async () => {
+			const mockClient = {};
+			const mockCache = {
+				get: mock.fn(() => [1, 2, 3])
+			};
+			const cacheClient = new CachedInspectorClient(mockClient, mockCache);
+			const inspectors = await cacheClient.getAllInspectors();
+			assert.strictEqual(mockCache.get.mock.callCount(), 1);
+			assert.deepStrictEqual(inspectors, [1, 2, 3]);
+		});
+		it('should fetch new value if no cache value', async () => {
+			const mockClient = { getAllInspectors: mock.fn(() => [3, 4, 5]) };
+			const mockCache = {
+				get: mock.fn(),
+				set: mock.fn()
+			};
+			const cacheClient = new CachedInspectorClient(mockClient, mockCache);
+			const cases = await cacheClient.getAllInspectors();
+			assert.deepStrictEqual(cases, [3, 4, 5]);
+			assert.strictEqual(mockClient.getAllInspectors.mock.callCount(), 1);
+			assert.strictEqual(mockCache.get.mock.callCount(), 1);
+			assert.strictEqual(mockCache.set.mock.callCount(), 1);
+		});
+	});
+});

--- a/packages/lib/data/database/inspector-client.js
+++ b/packages/lib/data/database/inspector-client.js
@@ -13,8 +13,6 @@ export class InspectorClient {
 	 */
 	constructor(dbClient) {
 		this.#client = dbClient;
-		console.info('made client');
-		console.info(this.#client);
 	}
 
 	/**
@@ -32,5 +30,13 @@ export class InspectorClient {
 				Specialisms: true
 			}
 		});
+	}
+
+	/**
+	 * Fetches a list of all inspectors in database
+	 * @returns {Promise<import('@pins/inspector-programming-database/src/client').Inspector[]>}
+	 */
+	async getAllInspectors() {
+		return this.#client.inspector.findMany({ include: { Specialisms: true } });
 	}
 }

--- a/packages/lib/data/database/inspector-client.js
+++ b/packages/lib/data/database/inspector-client.js
@@ -1,0 +1,36 @@
+/**
+ * Client for fetching inspector data from the Prisma database.
+ * Inspector data from Entra is fetched via src/app/inspector/inspector.js
+ *
+ * @module InspectorClient
+ */
+export class InspectorClient {
+	/** @type {import('@pins/inspector-programming-database/src/client').PrismaClient} */
+	#client;
+
+	/**
+	 * @param {import('@pins/inspector-programming-database/src/client').PrismaClient} dbClient
+	 */
+	constructor(dbClient) {
+		this.#client = dbClient;
+		console.info('made client');
+		console.info(this.#client);
+	}
+
+	/**
+	 *
+	 * @param {string|undefined} entraId
+	 * @returns {Promise<import('@pins/inspector-programming-database/src/client').Inspector|null>}
+	 */
+	async getInspectorDetails(entraId) {
+		if (!entraId) {
+			return null;
+		}
+		return this.#client.inspector.findFirst({
+			where: { entraId },
+			include: {
+				Specialisms: true
+			}
+		});
+	}
+}

--- a/packages/lib/data/database/inspector-client.test.js
+++ b/packages/lib/data/database/inspector-client.test.js
@@ -1,0 +1,39 @@
+import { describe, it, mock } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { InspectorClient } from './inspector-client.js';
+
+describe('InspectorClient', () => {
+	describe('getInspectorDetails', () => {
+		it('should return null if no inspectorId is provided', async () => {
+			const mockDb = {
+				inspectors: {
+					findUnique: mock.fn()
+				}
+			};
+			const client = new InspectorClient(mockDb);
+
+			const result = await client.getInspectorDetails(undefined);
+			assert.equal(result, null);
+		});
+		it('should return inspector if inspectorId is provided', async () => {
+			const mockInspector = {
+				id: '1',
+				firstName: 'John',
+				lastName: 'Doe'
+			};
+			const mockDb = {
+				inspector: {
+					findFirst: mock.fn(() => mockInspector)
+				}
+			};
+			const client = new InspectorClient(mockDb);
+
+			const result = await client.getInspectorDetails('entra-id-1');
+			assert.equal(result, mockInspector);
+			assert.equal(mockDb.inspector.findFirst.mock.callCount(), 1);
+			const args = mockDb.inspector.findFirst.mock.calls[0].arguments[0];
+			assert.deepEqual(args.where?.entraId, 'entra-id-1');
+			assert.deepEqual(args?.include, { Specialisms: true });
+		});
+	});
+});


### PR DESCRIPTION
## Describe your changes
Small PR to separate out database inspector code from Entra client inspector code. I create an inspectors client for hitting the db, complete with caching too for the fetch all inspectors query. I figured for fetching individual inspectors we wont really be needing any caching. 

I have introduced a new config for the caching called INSPECTORS_CACHE_TTL but this is optional for the program to run.

## Issue ticket number and link
https://pins-ds.atlassian.net.mcas.ms/jira/software/projects/PPB/boards/373?selectedIssue=PPB-170