### PR TITLE
feat/ppb 157 event allocation rules

### DIFF
--- a/apps/web/src/app/calendar/calendar.test.js
+++ b/apps/web/src/app/calendar/calendar.test.js
@@ -492,34 +492,13 @@ describe('calendar', () => {
 		beforeEach(() => {
 			mockCasesClient.getCaseById.mock.resetCalls();
 			mockCalendarClient.getAllCalendarEventTimingRules.mock.resetCalls();
+			mockCalendarClient.getEnglandWalesBankHolidays.mock.resetCalls();
 		});
+		//setup mock clients
 		const mockCalendarClient = {
-			getAllCalendarEventTimingRules: mock.fn()
+			getAllCalendarEventTimingRules: mock.fn(),
+			getEnglandWalesBankHolidays: mock.fn()
 		};
-		//two rules to choose from
-		const mockTimingRules = [
-			{
-				id: 1,
-				caseType: 'H',
-				caseProcedure: 'W',
-				allocationLevel: 'B',
-				CalendarEventTiming: { prepTime: 2.5, siteVisitTime: 3, reportTime: 2.5, costsTime: 1 }
-			},
-			{
-				id: 2,
-				caseType: 'D',
-				caseProcedure: 'W',
-				allocationLevel: 'C',
-				CalendarEventTiming: { prepTime: 3, siteVisitTime: 4, reportTime: 3, costsTime: 0.5 }
-			}
-		];
-		mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementation(() => mockTimingRules);
-		const mockCasesClient = {
-			getCaseById: mock.fn()
-		};
-		//one case fetched (unless overridden in test)
-		const appeal = { caseId: 'caseId', caseType: 'H', caseProcedure: 'W', caseLevel: 'B' };
-		mockCasesClient.getCaseById.mock.mockImplementation(() => appeal);
 		const mockService = () => {
 			return {
 				logger: mockLogger,
@@ -527,47 +506,105 @@ describe('calendar', () => {
 				calendarClient: mockCalendarClient
 			};
 		};
+		const mockCasesClient = {
+			getCaseById: mock.fn()
+		};
+
+		//mock data responses
+		const mockTimingRules = [
+			{
+				id: 1,
+				caseType: 'H',
+				caseProcedure: 'W',
+				allocationLevel: 'B',
+				CalendarEventTiming: { prepTime: 2, siteVisitTime: 3, reportTime: 2, costsTime: 1 }
+			},
+			{
+				id: 2,
+				caseType: 'D',
+				caseProcedure: 'W',
+				allocationLevel: 'C',
+				CalendarEventTiming: { prepTime: 3, siteVisitTime: 4, reportTime: 3, costsTime: 1 }
+			}
+		];
+		//one case fetched (unless overridden in test)
+		const appeal = {
+			caseId: 'caseId',
+			caseReference: 'ref1',
+			lpaName: 'test-lpa',
+			caseType: 'H',
+			caseProcedure: 'W',
+			caseLevel: 'B'
+		};
+
+		//mock implementations
+		mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementation(() => mockTimingRules);
+		mockCalendarClient.getEnglandWalesBankHolidays.mock.mockImplementation(() => []);
+		mockCasesClient.getCaseById.mock.mockImplementation(() => appeal);
+
+		//testing vars
+		const requiredProps = (/** @type {any} */ row) => {
+			['subject', 'start', 'end', 'location'].forEach((prop) => {
+				assert.ok(Object.prototype.hasOwnProperty.call(row, prop));
+			});
+		};
+
+		/**
+		 *
+		 * @param {any} row1
+		 * @param {any} row2
+		 * @param {any} row3
+		 * @param {any} row4
+		 */
+		const requiredStages = (row1, row2, row3, row4) => {
+			assert.ok(row1.subject.includes('prep'));
+			assert.ok(row2.subject.includes('siteVisit'));
+			assert.ok(row3.subject.includes('report'));
+			assert.ok(row4.subject.includes('costs'));
+		};
+
 		it('should generate a list of calendar event json objects for a case', async () => {
 			const service = mockService();
-			const res = await generateCaseCalendarEvents(service, '2025-10-10', [1]);
+			const res = await generateCaseCalendarEvents(service, '2025-10-08', [1]);
+
 			assert.strictEqual(mockCalendarClient.getAllCalendarEventTimingRules.mock.callCount(), 1);
-			assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 1);
+			//expect call count to be num cases * 4 (one per stage)
+			assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 4);
 			assert.strictEqual(res.length, 4);
-			assert.ok(Object.prototype.hasOwnProperty.call(res[0], 'subject'));
-			assert.ok(Object.prototype.hasOwnProperty.call(res[0], 'start'));
-			assert.ok(Object.prototype.hasOwnProperty.call(res[0], 'end'));
-			assert.ok(Object.prototype.hasOwnProperty.call(res[0], 'location'));
+
+			requiredProps(res[0]);
+			requiredStages(res[0], res[1], res[2], res[3]);
+
+			//check correct time allocation
+			assert.strictEqual(res[0].start.dateTime, '2025-10-07T09:00:00.000Z'); //prep
+			assert.strictEqual(res[0].end.dateTime, '2025-10-07T11:00:00.000Z');
+			assert.strictEqual(res[1].start.dateTime, '2025-10-08T09:00:00.000Z'); //siteVisit
+			assert.strictEqual(res[1].end.dateTime, '2025-10-08T12:00:00.000Z');
+			assert.strictEqual(res[2].start.dateTime, '2025-10-09T09:00:00.000Z'); //report
+			assert.strictEqual(res[2].end.dateTime, '2025-10-09T11:00:00.000Z');
+			assert.strictEqual(res[3].start.dateTime, '2025-10-10T09:00:00.000Z'); //costs
+			assert.strictEqual(res[3].end.dateTime, '2025-10-10T10:00:00.000Z');
 		});
 		it('multiple cases should yield multiple sets of json objects', async () => {
 			const service = mockService();
-			const res = await generateCaseCalendarEvents(service, '2025-10-10', [1, 2, 3]);
+			const res = await generateCaseCalendarEvents(service, '2025-10-08', [1, 2, 3]);
 			assert.strictEqual(mockCalendarClient.getAllCalendarEventTimingRules.mock.callCount(), 1);
-			assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 3);
+			assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 12); //3 cases * 4 stages
 			assert.strictEqual(res.length, 12);
-			assert.ok(Object.prototype.hasOwnProperty.call(res[0], 'subject'));
-			assert.ok(Object.prototype.hasOwnProperty.call(res[0], 'start'));
-			assert.ok(Object.prototype.hasOwnProperty.call(res[0], 'end'));
-			assert.ok(Object.prototype.hasOwnProperty.call(res[0], 'location'));
+
+			const [case1, case2, case3] = [
+				{ prep: res[0], siteVisit: res[3], report: res[6], costs: res[9] },
+				{ prep: res[1], siteVisit: res[4], report: res[7], costs: res[10] },
+				{ prep: res[2], siteVisit: res[5], report: res[8], costs: res[11] }
+			];
+
+			requiredProps(case1.prep);
+			//ensure multiple instances of each stage in correct order
+			requiredStages(case1.prep, case1.siteVisit, case1.report, case1.costs);
+			requiredStages(case2.prep, case2.siteVisit, case2.report, case2.costs);
+			requiredStages(case3.prep, case3.siteVisit, case3.report, case3.costs);
+
 			assert.ok(Object.prototype.hasOwnProperty.call(res[0], 'extensions'));
-		});
-		it('no case details found for caseId should error', async () => {
-			mockCasesClient.getCaseById.mock.mockImplementationOnce(() => undefined);
-			const service = mockService();
-			await assert.rejects(generateCaseCalendarEvents(service, '2025-10-10', [1, 2, 3]), {
-				message: 'Case details could not be fetched for case: 1'
-			});
-			assert.strictEqual(mockCalendarClient.getAllCalendarEventTimingRules.mock.callCount(), 1);
-			assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 1);
-		});
-		it('no timing rule matching case details should error', async () => {
-			const appeal = { caseId: 'caseId', caseType: 'A', caseProcedure: 'P', caseLevel: 'B' };
-			mockCasesClient.getCaseById.mock.mockImplementationOnce(() => appeal);
-			const service = mockService();
-			await assert.rejects(generateCaseCalendarEvents(service, '2025-10-10', [1, 2, 3]), {
-				message: 'No timing rules matching case: 1'
-			});
-			assert.strictEqual(mockCalendarClient.getAllCalendarEventTimingRules.mock.callCount(), 1);
-			assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 1);
 		});
 		it('calendar event extensions should only submit those that are provided', async () => {
 			const service = mockService();
@@ -576,6 +613,699 @@ describe('calendar', () => {
 			assert.strictEqual(res[0].extensions[0]['@odata.type'], 'microsoft.graph.openTypeExtension');
 			assert.strictEqual(res[0].extensions[0].extensionName, 'uk.gov.planninginspectorate.programming');
 			assert.ok(Object.prototype.hasOwnProperty.call(res[0].extensions[0], 'eventType'));
+		});
+		describe('error cases', () => {
+			it('no case details found for caseId should error', async () => {
+				mockCasesClient.getCaseById.mock.mockImplementationOnce(() => undefined);
+				const service = mockService();
+				await assert.rejects(generateCaseCalendarEvents(service, '2025-10-10', [1, 2, 3]), {
+					message: 'Case details could not be fetched for case: 1'
+				});
+				assert.strictEqual(mockCalendarClient.getAllCalendarEventTimingRules.mock.callCount(), 1);
+				assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 1);
+			});
+			it('no timing rule matching case details should error', async () => {
+				const appeal = { caseId: 'caseId', caseType: 'A', caseProcedure: 'P', caseLevel: 'B' };
+				mockCasesClient.getCaseById.mock.mockImplementationOnce(() => appeal);
+				const service = mockService();
+				await assert.rejects(generateCaseCalendarEvents(service, '2025-10-10', [1, 2, 3]), {
+					message: 'No timing rules matching case: 1'
+				});
+				assert.strictEqual(mockCalendarClient.getAllCalendarEventTimingRules.mock.callCount(), 1);
+				assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 1);
+			});
+		});
+		describe('handling events over weekends or bank holidays', () => {
+			it('setting the assignment date to a Monday will generate the prep event on the prior Friday', async () => {
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-22', [1]);
+				assert.strictEqual(mockCalendarClient.getAllCalendarEventTimingRules.mock.callCount(), 1);
+				assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 4);
+				assert.strictEqual(res.length, 4);
+
+				requiredProps(res[0]);
+				requiredStages(res[0], res[1], res[2], res[3]);
+
+				//check correct time allocation
+				assert.strictEqual(res[0].start.dateTime, '2025-09-19T09:00:00.000Z'); //prep
+				assert.strictEqual(res[0].end.dateTime, '2025-09-19T11:00:00.000Z');
+				assert.strictEqual(res[1].start.dateTime, '2025-09-22T09:00:00.000Z'); //siteVisit
+				assert.strictEqual(res[1].end.dateTime, '2025-09-22T12:00:00.000Z');
+				assert.strictEqual(res[2].start.dateTime, '2025-09-23T09:00:00.000Z'); //report
+				assert.strictEqual(res[2].end.dateTime, '2025-09-23T11:00:00.000Z');
+				assert.strictEqual(res[3].start.dateTime, '2025-09-24T09:00:00.000Z'); //costs
+				assert.strictEqual(res[3].end.dateTime, '2025-09-24T10:00:00.000Z');
+			});
+			it('setting the assignment date to a Sunday will generate the prep event on the prior Friday and increment all other days by 1', async () => {
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-21', [1]);
+				assert.strictEqual(mockCalendarClient.getAllCalendarEventTimingRules.mock.callCount(), 1);
+				assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 4);
+				assert.strictEqual(res.length, 4);
+
+				requiredProps(res[0]);
+				requiredStages(res[0], res[1], res[2], res[3]);
+
+				//check correct time allocation
+				assert.strictEqual(res[0].start.dateTime, '2025-09-19T09:00:00.000Z'); //prep
+				assert.strictEqual(res[0].end.dateTime, '2025-09-19T11:00:00.000Z');
+				assert.strictEqual(res[1].start.dateTime, '2025-09-22T09:00:00.000Z'); //siteVisit
+				assert.strictEqual(res[1].end.dateTime, '2025-09-22T12:00:00.000Z');
+				assert.strictEqual(res[2].start.dateTime, '2025-09-23T09:00:00.000Z'); //report
+				assert.strictEqual(res[2].end.dateTime, '2025-09-23T11:00:00.000Z');
+				assert.strictEqual(res[3].start.dateTime, '2025-09-24T09:00:00.000Z'); //costs
+				assert.strictEqual(res[3].end.dateTime, '2025-09-24T10:00:00.000Z');
+			});
+			it('setting the assignment date to a Saturday will generate the prep event on the prior Friday and increment all other days by 2', async () => {
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-20', [1]);
+				assert.strictEqual(mockCalendarClient.getAllCalendarEventTimingRules.mock.callCount(), 1);
+				assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 4);
+				assert.strictEqual(res.length, 4);
+
+				requiredProps(res[0]);
+				requiredStages(res[0], res[1], res[2], res[3]);
+
+				//check correct time allocation
+				assert.strictEqual(res[0].start.dateTime, '2025-09-19T09:00:00.000Z'); //prep
+				assert.strictEqual(res[0].end.dateTime, '2025-09-19T11:00:00.000Z');
+				assert.strictEqual(res[1].start.dateTime, '2025-09-22T09:00:00.000Z'); //siteVisit
+				assert.strictEqual(res[1].end.dateTime, '2025-09-22T12:00:00.000Z');
+				assert.strictEqual(res[2].start.dateTime, '2025-09-23T09:00:00.000Z'); //report
+				assert.strictEqual(res[2].end.dateTime, '2025-09-23T11:00:00.000Z');
+				assert.strictEqual(res[3].start.dateTime, '2025-09-24T09:00:00.000Z'); //costs
+				assert.strictEqual(res[3].end.dateTime, '2025-09-24T10:00:00.000Z');
+			});
+			it('setting the assignment date to a Friday will offload report and costs stages onto the next week', async () => {
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-19', [1]);
+				assert.strictEqual(mockCalendarClient.getAllCalendarEventTimingRules.mock.callCount(), 1);
+				assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 4);
+				assert.strictEqual(res.length, 4);
+
+				requiredProps(res[0]);
+				requiredStages(res[0], res[1], res[2], res[3]);
+
+				//check correct time allocation
+				assert.strictEqual(res[0].start.dateTime, '2025-09-18T09:00:00.000Z'); //prep
+				assert.strictEqual(res[0].end.dateTime, '2025-09-18T11:00:00.000Z');
+				assert.strictEqual(res[1].start.dateTime, '2025-09-19T09:00:00.000Z'); //siteVisit
+				assert.strictEqual(res[1].end.dateTime, '2025-09-19T12:00:00.000Z');
+				assert.strictEqual(res[2].start.dateTime, '2025-09-22T09:00:00.000Z'); //report
+				assert.strictEqual(res[2].end.dateTime, '2025-09-22T11:00:00.000Z');
+				assert.strictEqual(res[3].start.dateTime, '2025-09-23T09:00:00.000Z'); //costs
+				assert.strictEqual(res[3].end.dateTime, '2025-09-23T10:00:00.000Z');
+			});
+			it('setting the assignment date to a Thursday will offload costs stage onto the next week', async () => {
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-18', [1]);
+				assert.strictEqual(mockCalendarClient.getAllCalendarEventTimingRules.mock.callCount(), 1);
+				assert.strictEqual(mockCasesClient.getCaseById.mock.callCount(), 4);
+				assert.strictEqual(res.length, 4);
+
+				requiredProps(res[0]);
+				requiredStages(res[0], res[1], res[2], res[3]);
+
+				//check correct time allocation
+				assert.strictEqual(res[0].start.dateTime, '2025-09-17T09:00:00.000Z'); //prep
+				assert.strictEqual(res[0].end.dateTime, '2025-09-17T11:00:00.000Z');
+				assert.strictEqual(res[1].start.dateTime, '2025-09-18T09:00:00.000Z'); //siteVisit
+				assert.strictEqual(res[1].end.dateTime, '2025-09-18T12:00:00.000Z');
+				assert.strictEqual(res[2].start.dateTime, '2025-09-19T09:00:00.000Z'); //report
+				assert.strictEqual(res[2].end.dateTime, '2025-09-19T11:00:00.000Z');
+				assert.strictEqual(res[3].start.dateTime, '2025-09-22T09:00:00.000Z'); //costs
+				assert.strictEqual(res[3].end.dateTime, '2025-09-22T10:00:00.000Z');
+			});
+			it('bank holidays should be accounted for when allocating events', async () => {
+				mockCalendarClient.getEnglandWalesBankHolidays.mock.mockImplementationOnce(() => ['2025-09-29']);
+
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-25', [1]);
+				assert.strictEqual(mockCalendarClient.getEnglandWalesBankHolidays.mock.callCount(), 1);
+				assert.strictEqual(res.length, 4);
+
+				const case1 = { prep: res[0], siteVisit: res[1], report: res[2], costs: res[3] };
+
+				requiredProps(case1.report);
+				requiredStages(case1.prep, case1.siteVisit, case1.report, case1.costs);
+
+				assert.strictEqual(case1.prep.start.dateTime, '2025-09-24T09:00:00.000Z');
+				assert.strictEqual(case1.prep.end.dateTime, '2025-09-24T11:00:00.000Z');
+				assert.strictEqual(case1.siteVisit.start.dateTime, '2025-09-25T09:00:00.000Z');
+				assert.strictEqual(case1.siteVisit.end.dateTime, '2025-09-25T12:00:00.000Z');
+				assert.strictEqual(case1.report.start.dateTime, '2025-09-26T09:00:00.000Z');
+				assert.strictEqual(case1.report.end.dateTime, '2025-09-26T11:00:00.000Z');
+				assert.strictEqual(case1.costs.start.dateTime, '2025-09-30T09:00:00.000Z');
+				assert.strictEqual(case1.costs.end.dateTime, '2025-09-30T10:00:00.000Z');
+			});
+			it('bank holidays should be accounted for when allocating events for multiple cases', async () => {
+				mockCalendarClient.getEnglandWalesBankHolidays.mock.mockImplementationOnce(() => ['2025-09-29']);
+
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-26', [1, 2, 3]);
+				assert.strictEqual(mockCalendarClient.getEnglandWalesBankHolidays.mock.callCount(), 1);
+				assert.strictEqual(res.length, 12);
+
+				const [case1, case2, case3] = [
+					{ prep: res[0], siteVisit: res[3], report: res[6], costs: res[9] },
+					{ prep: res[1], siteVisit: res[4], report: res[7], costs: res[10] },
+					{ prep: res[2], siteVisit: res[5], report: res[8], costs: res[11] }
+				];
+
+				assert.strictEqual(case1.prep.start.dateTime, '2025-09-25T09:00:00.000Z');
+				assert.strictEqual(case1.prep.end.dateTime, '2025-09-25T11:00:00.000Z');
+				assert.strictEqual(case2.prep.start.dateTime, '2025-09-25T11:00:00.000Z');
+				assert.strictEqual(case2.prep.end.dateTime, '2025-09-25T13:00:00.000Z');
+				assert.strictEqual(case3.prep.start.dateTime, '2025-09-25T13:00:00.000Z');
+				assert.strictEqual(case3.prep.end.dateTime, '2025-09-25T15:00:00.000Z');
+				assert.strictEqual(case1.siteVisit.start.dateTime, '2025-09-26T09:00:00.000Z');
+				assert.strictEqual(case1.siteVisit.end.dateTime, '2025-09-26T12:00:00.000Z');
+				assert.strictEqual(case2.siteVisit.start.dateTime, '2025-09-26T12:00:00.000Z');
+				assert.strictEqual(case2.siteVisit.end.dateTime, '2025-09-26T15:00:00.000Z');
+				assert.strictEqual(case3.siteVisit.start.dateTime, '2025-09-30T09:00:00.000Z');
+				assert.strictEqual(case3.siteVisit.end.dateTime, '2025-09-30T12:00:00.000Z');
+				assert.strictEqual(case1.report.start.dateTime, '2025-10-01T09:00:00.000Z');
+				assert.strictEqual(case1.report.end.dateTime, '2025-10-01T11:00:00.000Z');
+				assert.strictEqual(case2.report.start.dateTime, '2025-10-01T11:00:00.000Z');
+				assert.strictEqual(case2.report.end.dateTime, '2025-10-01T13:00:00.000Z');
+				assert.strictEqual(case3.report.start.dateTime, '2025-10-01T13:00:00.000Z');
+				assert.strictEqual(case3.report.end.dateTime, '2025-10-01T15:00:00.000Z');
+				assert.strictEqual(case1.costs.start.dateTime, '2025-10-02T09:00:00.000Z');
+				assert.strictEqual(case1.costs.end.dateTime, '2025-10-02T10:00:00.000Z');
+				assert.strictEqual(case2.costs.start.dateTime, '2025-10-02T10:00:00.000Z');
+				assert.strictEqual(case2.costs.end.dateTime, '2025-10-02T11:00:00.000Z');
+				assert.strictEqual(case3.costs.start.dateTime, '2025-10-02T11:00:00.000Z');
+				assert.strictEqual(case3.costs.end.dateTime, '2025-10-02T12:00:00.000Z');
+			});
+		});
+		describe('allocating events with respect to existing events', () => {
+			it("multiple cases' events should be allocated around one another, back to back on the correct days", async () => {
+				//three 3h events back to back exceeds 8 hour limit
+				mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementationOnce(() => {
+					return [
+						{
+							id: 1,
+							caseType: 'H',
+							caseProcedure: 'W',
+							allocationLevel: 'B',
+							CalendarEventTiming: { prepTime: 2, siteVisitTime: 2, reportTime: 1, costsTime: 1 }
+						}
+					];
+				});
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-24', [1, 2, 3]);
+				const [case1, case2, case3] = [
+					{ prep: res[0], siteVisit: res[3], report: res[6], costs: res[9] },
+					{ prep: res[1], siteVisit: res[4], report: res[7], costs: res[10] },
+					{ prep: res[2], siteVisit: res[5], report: res[8], costs: res[11] }
+				];
+
+				requiredProps(case1.prep);
+				requiredStages(case1.prep, case1.siteVisit, case1.report, case1.costs);
+				requiredStages(case2.prep, case2.siteVisit, case2.report, case2.costs);
+				requiredStages(case3.prep, case3.siteVisit, case3.report, case3.costs);
+
+				//case1
+				assert.strictEqual(case1.prep.start.dateTime, '2025-09-23T09:00:00.000Z'); //prep
+				assert.strictEqual(case1.prep.end.dateTime, '2025-09-23T11:00:00.000Z');
+				assert.strictEqual(case1.siteVisit.start.dateTime, '2025-09-24T09:00:00.000Z'); //siteVisit
+				assert.strictEqual(case1.siteVisit.end.dateTime, '2025-09-24T11:00:00.000Z');
+				assert.strictEqual(case1.report.start.dateTime, '2025-09-25T09:00:00.000Z'); //report
+				assert.strictEqual(case1.report.end.dateTime, '2025-09-25T10:00:00.000Z');
+				assert.strictEqual(case1.costs.start.dateTime, '2025-09-26T09:00:00.000Z'); //costs
+				assert.strictEqual(case1.costs.end.dateTime, '2025-09-26T10:00:00.000Z');
+
+				//case2 should come straight after case1
+				assert.strictEqual(case2.prep.start.dateTime, '2025-09-23T11:00:00.000Z'); //prep
+				assert.strictEqual(case2.prep.end.dateTime, '2025-09-23T13:00:00.000Z');
+				assert.strictEqual(case2.siteVisit.start.dateTime, '2025-09-24T11:00:00.000Z'); //siteVisit
+				assert.strictEqual(case2.siteVisit.end.dateTime, '2025-09-24T13:00:00.000Z');
+				assert.strictEqual(case2.report.start.dateTime, '2025-09-25T10:00:00.000Z'); //report
+				assert.strictEqual(case2.report.end.dateTime, '2025-09-25T11:00:00.000Z');
+				assert.strictEqual(case2.costs.start.dateTime, '2025-09-26T10:00:00.000Z'); //costs
+				assert.strictEqual(case2.costs.end.dateTime, '2025-09-26T11:00:00.000Z');
+
+				//case3 should come straight after case2
+				assert.strictEqual(case3.prep.start.dateTime, '2025-09-23T13:00:00.000Z'); //prep
+				assert.strictEqual(case3.prep.end.dateTime, '2025-09-23T15:00:00.000Z');
+				assert.strictEqual(case3.siteVisit.start.dateTime, '2025-09-24T13:00:00.000Z'); //siteVisit
+				assert.strictEqual(case3.siteVisit.end.dateTime, '2025-09-24T15:00:00.000Z');
+				assert.strictEqual(case3.report.start.dateTime, '2025-09-25T11:00:00.000Z'); //report
+				assert.strictEqual(case3.report.end.dateTime, '2025-09-25T12:00:00.000Z');
+				assert.strictEqual(case3.costs.start.dateTime, '2025-09-26T11:00:00.000Z'); //costs
+				assert.strictEqual(case3.costs.end.dateTime, '2025-09-26T12:00:00.000Z');
+			});
+		});
+		describe('manipulating larger event allocations', () => {
+			it('site visit timing rules over 8 hours will be split into chunks of 8 hours and logged individually, wrapping onto next week in required', async () => {
+				mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementationOnce(() => {
+					return [
+						{
+							id: 1,
+							caseType: 'H',
+							caseProcedure: 'W',
+							allocationLevel: 'B',
+							CalendarEventTiming: { prepTime: 4, siteVisitTime: 12, reportTime: 3, costsTime: 2 }
+						}
+					];
+				});
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-24', [1]);
+				const caseEvents = { prep: res[0], siteVisit1: res[1], siteVisit2: res[2], report: res[3], costs: res[4] };
+
+				requiredProps(caseEvents.prep);
+				requiredStages(caseEvents.prep, caseEvents.siteVisit1, caseEvents.report, caseEvents.costs);
+				assert.ok(caseEvents.siteVisit1.subject.includes('siteVisit - 8'));
+				assert.ok(caseEvents.siteVisit2.subject.includes('siteVisit - 4'));
+
+				assert.strictEqual(res.length, 5);
+
+				assert.strictEqual(caseEvents.prep.start.dateTime, '2025-09-23T09:00:00.000Z');
+				assert.strictEqual(caseEvents.prep.end.dateTime, '2025-09-23T13:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit1.start.dateTime, '2025-09-24T09:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit1.end.dateTime, '2025-09-24T17:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit2.start.dateTime, '2025-09-25T09:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit2.end.dateTime, '2025-09-25T13:00:00.000Z');
+				assert.strictEqual(caseEvents.report.start.dateTime, '2025-09-26T09:00:00.000Z');
+				assert.strictEqual(caseEvents.report.end.dateTime, '2025-09-26T12:00:00.000Z');
+				assert.strictEqual(caseEvents.costs.start.dateTime, '2025-09-29T09:00:00.000Z');
+				assert.strictEqual(caseEvents.costs.end.dateTime, '2025-09-29T11:00:00.000Z');
+			});
+			it('report timing rules over 8 hours will be split into chunks of 8 hours and logged individually', async () => {
+				mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementationOnce(() => {
+					return [
+						{
+							id: 1,
+							caseType: 'H',
+							caseProcedure: 'W',
+							allocationLevel: 'B',
+							CalendarEventTiming: { prepTime: 4, siteVisitTime: 6, reportTime: 14, costsTime: 2 }
+						}
+					];
+				});
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-24', [1]);
+				const caseEvents = { prep: res[0], siteVisit: res[1], report1: res[2], report2: res[3], costs: res[4] };
+
+				requiredProps(caseEvents.prep);
+				requiredStages(caseEvents.prep, caseEvents.siteVisit, caseEvents.report1, caseEvents.costs);
+				assert.ok(caseEvents.report1.subject.includes('report - 8'));
+				assert.ok(caseEvents.report2.subject.includes('report - 6'));
+
+				assert.strictEqual(res.length, 5);
+
+				assert.strictEqual(caseEvents.prep.start.dateTime, '2025-09-23T09:00:00.000Z');
+				assert.strictEqual(caseEvents.prep.end.dateTime, '2025-09-23T13:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit.start.dateTime, '2025-09-24T09:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit.end.dateTime, '2025-09-24T15:00:00.000Z');
+				assert.strictEqual(caseEvents.report1.start.dateTime, '2025-09-25T09:00:00.000Z');
+				assert.strictEqual(caseEvents.report1.end.dateTime, '2025-09-25T17:00:00.000Z');
+				assert.strictEqual(caseEvents.report2.start.dateTime, '2025-09-26T09:00:00.000Z');
+				assert.strictEqual(caseEvents.report2.end.dateTime, '2025-09-26T15:00:00.000Z');
+				assert.strictEqual(caseEvents.costs.start.dateTime, '2025-09-29T09:00:00.000Z');
+				assert.strictEqual(caseEvents.costs.end.dateTime, '2025-09-29T11:00:00.000Z');
+			});
+			it('prep timing rules over 8 hours will be split into chunks of 8 hours and logged individually, moving backwards from assignment date as required', async () => {
+				mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementationOnce(() => {
+					return [
+						{
+							id: 1,
+							caseType: 'H',
+							caseProcedure: 'W',
+							allocationLevel: 'B',
+							CalendarEventTiming: { prepTime: 10, siteVisitTime: 3, reportTime: 2, costsTime: 2 }
+						}
+					];
+				});
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-24', [1]);
+				const caseEvents = { prep1: res[0], prep2: res[1], siteVisit: res[2], report: res[3], costs: res[4] };
+
+				requiredProps(caseEvents.prep1);
+				requiredStages(caseEvents.prep1, caseEvents.siteVisit, caseEvents.report, caseEvents.costs);
+				assert.ok(caseEvents.prep1.subject.includes('prep - 8'));
+				assert.ok(caseEvents.prep2.subject.includes('prep - 2'));
+
+				assert.strictEqual(res.length, 5);
+
+				assert.strictEqual(caseEvents.prep1.start.dateTime, '2025-09-23T09:00:00.000Z');
+				assert.strictEqual(caseEvents.prep1.end.dateTime, '2025-09-23T17:00:00.000Z');
+				assert.strictEqual(caseEvents.prep2.start.dateTime, '2025-09-22T09:00:00.000Z');
+				assert.strictEqual(caseEvents.prep2.end.dateTime, '2025-09-22T11:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit.start.dateTime, '2025-09-24T09:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit.end.dateTime, '2025-09-24T12:00:00.000Z');
+				assert.strictEqual(caseEvents.report.start.dateTime, '2025-09-25T09:00:00.000Z');
+				assert.strictEqual(caseEvents.report.end.dateTime, '2025-09-25T11:00:00.000Z');
+				assert.strictEqual(caseEvents.costs.start.dateTime, '2025-09-26T09:00:00.000Z');
+				assert.strictEqual(caseEvents.costs.end.dateTime, '2025-09-26T11:00:00.000Z');
+			});
+			it('costs timing rules over 8 hours will be split into chunks of 8 hours. Split events also respect weekends', async () => {
+				mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementationOnce(() => {
+					return [
+						{
+							id: 1,
+							caseType: 'H',
+							caseProcedure: 'W',
+							allocationLevel: 'B',
+							CalendarEventTiming: { prepTime: 2, siteVisitTime: 3, reportTime: 2, costsTime: 16 }
+						}
+					];
+				});
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-24', [1]);
+				const caseEvents = { prep: res[0], siteVisit: res[1], report: res[2], costs1: res[3], costs2: res[4] };
+
+				requiredProps(caseEvents.prep);
+				requiredStages(caseEvents.prep, caseEvents.siteVisit, caseEvents.report, caseEvents.costs1);
+				assert.ok(caseEvents.costs1.subject.includes('costs - 8'));
+				assert.ok(caseEvents.costs2.subject.includes('costs - 8'));
+
+				assert.strictEqual(res.length, 5);
+
+				assert.strictEqual(caseEvents.prep.start.dateTime, '2025-09-23T09:00:00.000Z');
+				assert.strictEqual(caseEvents.prep.end.dateTime, '2025-09-23T11:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit.start.dateTime, '2025-09-24T09:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit.end.dateTime, '2025-09-24T12:00:00.000Z');
+				assert.strictEqual(caseEvents.report.start.dateTime, '2025-09-25T09:00:00.000Z');
+				assert.strictEqual(caseEvents.report.end.dateTime, '2025-09-25T11:00:00.000Z');
+				assert.strictEqual(caseEvents.costs1.start.dateTime, '2025-09-26T09:00:00.000Z');
+				assert.strictEqual(caseEvents.costs1.end.dateTime, '2025-09-26T17:00:00.000Z');
+				assert.strictEqual(caseEvents.costs2.start.dateTime, '2025-09-29T09:00:00.000Z');
+				assert.strictEqual(caseEvents.costs2.end.dateTime, '2025-09-29T17:00:00.000Z');
+			});
+			it('handle multiple split events going in both directions, respecting weekends', async () => {
+				mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementationOnce(() => {
+					return [
+						{
+							id: 1,
+							caseType: 'H',
+							caseProcedure: 'W',
+							allocationLevel: 'B',
+							CalendarEventTiming: { prepTime: 12, siteVisitTime: 12, reportTime: 10, costsTime: 2 }
+						}
+					];
+				});
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-24', [1]);
+				const caseEvents = {
+					prep1: res[0],
+					prep2: res[1],
+					siteVisit1: res[2],
+					siteVisit2: res[3],
+					report1: res[4],
+					report2: res[5],
+					costs: res[6]
+				};
+
+				requiredProps(caseEvents.prep1);
+				requiredStages(caseEvents.prep1, caseEvents.siteVisit1, caseEvents.report1, caseEvents.costs);
+				assert.ok(caseEvents.prep1.subject.includes('prep - 8'));
+				assert.ok(caseEvents.prep2.subject.includes('prep - 4'));
+				assert.ok(caseEvents.siteVisit1.subject.includes('siteVisit - 8'));
+				assert.ok(caseEvents.siteVisit2.subject.includes('siteVisit - 4'));
+				assert.ok(caseEvents.report1.subject.includes('report - 8'));
+				assert.ok(caseEvents.report2.subject.includes('report - 2'));
+
+				assert.strictEqual(res.length, 7);
+
+				assert.strictEqual(caseEvents.prep1.start.dateTime, '2025-09-23T09:00:00.000Z');
+				assert.strictEqual(caseEvents.prep1.end.dateTime, '2025-09-23T17:00:00.000Z');
+				assert.strictEqual(caseEvents.prep2.start.dateTime, '2025-09-22T09:00:00.000Z');
+				assert.strictEqual(caseEvents.prep2.end.dateTime, '2025-09-22T13:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit1.start.dateTime, '2025-09-24T09:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit1.end.dateTime, '2025-09-24T17:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit2.start.dateTime, '2025-09-25T09:00:00.000Z');
+				assert.strictEqual(caseEvents.siteVisit2.end.dateTime, '2025-09-25T13:00:00.000Z');
+				assert.strictEqual(caseEvents.report1.start.dateTime, '2025-09-26T09:00:00.000Z');
+				assert.strictEqual(caseEvents.report1.end.dateTime, '2025-09-26T17:00:00.000Z');
+				assert.strictEqual(caseEvents.report2.start.dateTime, '2025-09-29T09:00:00.000Z');
+				assert.strictEqual(caseEvents.report2.end.dateTime, '2025-09-29T11:00:00.000Z');
+				assert.strictEqual(caseEvents.costs.start.dateTime, '2025-09-30T09:00:00.000Z');
+				assert.strictEqual(caseEvents.costs.end.dateTime, '2025-09-30T11:00:00.000Z');
+			});
+			it('handle multiple cases with split events', async () => {
+				mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementationOnce(() => {
+					return [
+						{
+							id: 1,
+							caseType: 'H',
+							caseProcedure: 'W',
+							allocationLevel: 'B',
+							CalendarEventTiming: { prepTime: 4, siteVisitTime: 12, reportTime: 4, costsTime: 2 }
+						}
+					];
+				});
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-10', [1, 2, 3]);
+				const [case1, case2, case3] = [
+					{ prep: res[0], siteVisit1: res[3], siteVisit2: res[4], report: res[9], costs: res[12] },
+					{ prep: res[1], siteVisit1: res[5], siteVisit2: res[6], report: res[10], costs: res[13] },
+					{ prep: res[2], siteVisit1: res[7], siteVisit2: res[8], report: res[11], costs: res[14] }
+				];
+
+				requiredProps(case1.siteVisit1);
+				requiredProps(case2.report);
+				requiredProps(case3.costs);
+
+				assert.ok(case1.siteVisit1.subject.includes('siteVisit - 8'));
+				assert.ok(case1.siteVisit2.subject.includes('siteVisit - 4'));
+				assert.ok(case2.siteVisit1.subject.includes('siteVisit - 8'));
+				assert.ok(case2.siteVisit2.subject.includes('siteVisit - 4'));
+				assert.ok(case3.siteVisit1.subject.includes('siteVisit - 8'));
+				assert.ok(case3.siteVisit2.subject.includes('siteVisit - 4'));
+
+				assert.strictEqual(res.length, 15);
+
+				assert.strictEqual(case1.prep.start.dateTime, '2025-09-09T09:00:00.000Z');
+				assert.strictEqual(case1.prep.end.dateTime, '2025-09-09T13:00:00.000Z');
+				assert.strictEqual(case2.prep.start.dateTime, '2025-09-09T13:00:00.000Z');
+				assert.strictEqual(case2.prep.end.dateTime, '2025-09-09T17:00:00.000Z');
+				assert.strictEqual(case3.prep.start.dateTime, '2025-09-08T09:00:00.000Z');
+				assert.strictEqual(case3.prep.end.dateTime, '2025-09-08T13:00:00.000Z');
+				assert.strictEqual(case1.siteVisit1.start.dateTime, '2025-09-10T09:00:00.000Z');
+				assert.strictEqual(case1.siteVisit1.end.dateTime, '2025-09-10T17:00:00.000Z');
+				assert.strictEqual(case1.siteVisit2.start.dateTime, '2025-09-11T09:00:00.000Z');
+				assert.strictEqual(case1.siteVisit2.end.dateTime, '2025-09-11T13:00:00.000Z');
+				assert.strictEqual(case2.siteVisit1.start.dateTime, '2025-09-12T09:00:00.000Z');
+				assert.strictEqual(case2.siteVisit1.end.dateTime, '2025-09-12T17:00:00.000Z');
+				assert.strictEqual(case2.siteVisit2.start.dateTime, '2025-09-15T09:00:00.000Z'); // technically could be put on 11th but much safer to not look backwards when assigning split cases
+				assert.strictEqual(case2.siteVisit2.end.dateTime, '2025-09-15T13:00:00.000Z');
+				assert.strictEqual(case3.siteVisit1.start.dateTime, '2025-09-16T09:00:00.000Z');
+				assert.strictEqual(case3.siteVisit1.end.dateTime, '2025-09-16T17:00:00.000Z');
+				assert.strictEqual(case3.siteVisit2.start.dateTime, '2025-09-17T09:00:00.000Z');
+				assert.strictEqual(case3.siteVisit2.end.dateTime, '2025-09-17T13:00:00.000Z');
+				assert.strictEqual(case1.report.start.dateTime, '2025-09-18T09:00:00.000Z');
+				assert.strictEqual(case1.report.end.dateTime, '2025-09-18T13:00:00.000Z');
+				assert.strictEqual(case2.report.start.dateTime, '2025-09-18T13:00:00.000Z');
+				assert.strictEqual(case2.report.end.dateTime, '2025-09-18T17:00:00.000Z');
+				assert.strictEqual(case3.report.start.dateTime, '2025-09-19T09:00:00.000Z');
+				assert.strictEqual(case3.report.end.dateTime, '2025-09-19T13:00:00.000Z');
+				assert.strictEqual(case1.costs.start.dateTime, '2025-09-22T09:00:00.000Z');
+				assert.strictEqual(case1.costs.end.dateTime, '2025-09-22T11:00:00.000Z');
+				assert.strictEqual(case2.costs.start.dateTime, '2025-09-22T11:00:00.000Z');
+				assert.strictEqual(case2.costs.end.dateTime, '2025-09-22T13:00:00.000Z');
+				assert.strictEqual(case3.costs.start.dateTime, '2025-09-22T13:00:00.000Z');
+				assert.strictEqual(case3.costs.end.dateTime, '2025-09-22T15:00:00.000Z');
+			});
+			it('handle multiple cases with split prep events', async () => {
+				mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementationOnce(() => {
+					return [
+						{
+							id: 1,
+							caseType: 'H',
+							caseProcedure: 'W',
+							allocationLevel: 'B',
+							CalendarEventTiming: { prepTime: 12, siteVisitTime: 4, reportTime: 4, costsTime: 2 }
+						}
+					];
+				});
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-10', [1, 2, 3]);
+				console.info(res);
+				const [case1, case2, case3] = [
+					{ prep1: res[0], prep2: res[1], siteVisit: res[6], report: res[9], costs: res[12] },
+					{ prep1: res[2], prep2: res[3], siteVisit: res[7], report: res[10], costs: res[13] },
+					{ prep1: res[4], prep2: res[5], siteVisit: res[8], report: res[11], costs: res[14] }
+				];
+
+				requiredProps(case1.prep1);
+				requiredProps(case2.prep2);
+				requiredProps(case3.costs);
+
+				assert.ok(case1.prep1.subject.includes('prep - 8'));
+				assert.ok(case1.prep2.subject.includes('prep - 4'));
+				assert.ok(case2.prep1.subject.includes('prep - 8'));
+				assert.ok(case2.prep2.subject.includes('prep - 4'));
+				assert.ok(case3.prep1.subject.includes('prep - 8'));
+				assert.ok(case3.prep2.subject.includes('prep - 4'));
+
+				assert.strictEqual(res.length, 15);
+
+				assert.strictEqual(case1.prep1.start.dateTime, '2025-09-09T09:00:00.000Z'); //prep events go backwards because case1 assigned first, then case2
+				assert.strictEqual(case1.prep1.end.dateTime, '2025-09-09T17:00:00.000Z');
+				assert.strictEqual(case1.prep2.start.dateTime, '2025-09-08T09:00:00.000Z');
+				assert.strictEqual(case1.prep2.end.dateTime, '2025-09-08T13:00:00.000Z');
+				assert.strictEqual(case2.prep1.start.dateTime, '2025-09-05T09:00:00.000Z');
+				assert.strictEqual(case2.prep1.end.dateTime, '2025-09-05T17:00:00.000Z');
+				assert.strictEqual(case2.prep2.start.dateTime, '2025-09-04T09:00:00.000Z');
+				assert.strictEqual(case2.prep2.end.dateTime, '2025-09-04T13:00:00.000Z');
+				assert.strictEqual(case3.prep1.start.dateTime, '2025-09-03T09:00:00.000Z');
+				assert.strictEqual(case3.prep1.end.dateTime, '2025-09-03T17:00:00.000Z');
+				assert.strictEqual(case3.prep2.start.dateTime, '2025-09-02T09:00:00.000Z');
+				assert.strictEqual(case3.prep2.end.dateTime, '2025-09-02T13:00:00.000Z');
+				assert.strictEqual(case1.siteVisit.start.dateTime, '2025-09-10T09:00:00.000Z');
+				assert.strictEqual(case1.siteVisit.end.dateTime, '2025-09-10T13:00:00.000Z');
+				assert.strictEqual(case2.siteVisit.start.dateTime, '2025-09-10T13:00:00.000Z');
+				assert.strictEqual(case2.siteVisit.end.dateTime, '2025-09-10T17:00:00.000Z');
+				assert.strictEqual(case3.siteVisit.start.dateTime, '2025-09-11T09:00:00.000Z');
+				assert.strictEqual(case3.siteVisit.end.dateTime, '2025-09-11T13:00:00.000Z');
+				assert.strictEqual(case1.report.start.dateTime, '2025-09-12T09:00:00.000Z');
+				assert.strictEqual(case1.report.end.dateTime, '2025-09-12T13:00:00.000Z');
+				assert.strictEqual(case2.report.start.dateTime, '2025-09-12T13:00:00.000Z');
+				assert.strictEqual(case2.report.end.dateTime, '2025-09-12T17:00:00.000Z');
+				assert.strictEqual(case3.report.start.dateTime, '2025-09-15T09:00:00.000Z');
+				assert.strictEqual(case3.report.end.dateTime, '2025-09-15T13:00:00.000Z');
+				assert.strictEqual(case1.costs.start.dateTime, '2025-09-16T09:00:00.000Z');
+				assert.strictEqual(case1.costs.end.dateTime, '2025-09-16T11:00:00.000Z');
+				assert.strictEqual(case2.costs.start.dateTime, '2025-09-16T11:00:00.000Z');
+				assert.strictEqual(case2.costs.end.dateTime, '2025-09-16T13:00:00.000Z');
+				assert.strictEqual(case3.costs.start.dateTime, '2025-09-16T13:00:00.000Z');
+				assert.strictEqual(case3.costs.end.dateTime, '2025-09-16T15:00:00.000Z');
+			});
+			it('handle multiple events that overrun the 8 hour daily limit and straddle the weekend', async () => {
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-10', [1, 2, 3, 4, 5]);
+				const [case1, case2, case3, case4, case5] = [
+					{ prep: res[0], siteVisit: res[5], report: res[10], costs: res[15] },
+					{ prep: res[1], siteVisit: res[6], report: res[11], costs: res[16] },
+					{ prep: res[2], siteVisit: res[7], report: res[12], costs: res[17] },
+					{ prep: res[3], siteVisit: res[8], report: res[13], costs: res[18] },
+					{ prep: res[4], siteVisit: res[9], report: res[14], costs: res[19] }
+				];
+
+				requiredStages(case1.prep, case1.siteVisit, case1.report, case1.costs);
+				requiredProps(case1.siteVisit);
+				requiredProps(case2.report);
+				requiredProps(case3.costs);
+
+				assert.strictEqual(res.length, 20);
+
+				assert.strictEqual(case1.prep.start.dateTime, '2025-09-09T09:00:00.000Z');
+				assert.strictEqual(case1.prep.end.dateTime, '2025-09-09T11:00:00.000Z');
+				assert.strictEqual(case2.prep.start.dateTime, '2025-09-09T11:00:00.000Z');
+				assert.strictEqual(case2.prep.end.dateTime, '2025-09-09T13:00:00.000Z');
+				assert.strictEqual(case3.prep.start.dateTime, '2025-09-09T13:00:00.000Z');
+				assert.strictEqual(case3.prep.end.dateTime, '2025-09-09T15:00:00.000Z');
+				assert.strictEqual(case4.prep.start.dateTime, '2025-09-09T15:00:00.000Z');
+				assert.strictEqual(case4.prep.end.dateTime, '2025-09-09T17:00:00.000Z');
+				assert.strictEqual(case5.prep.start.dateTime, '2025-09-08T09:00:00.000Z');
+				assert.strictEqual(case5.prep.end.dateTime, '2025-09-08T11:00:00.000Z');
+				assert.strictEqual(case1.siteVisit.start.dateTime, '2025-09-10T09:00:00.000Z');
+				assert.strictEqual(case1.siteVisit.end.dateTime, '2025-09-10T12:00:00.000Z');
+				assert.strictEqual(case2.siteVisit.start.dateTime, '2025-09-10T12:00:00.000Z');
+				assert.strictEqual(case2.siteVisit.end.dateTime, '2025-09-10T15:00:00.000Z');
+				assert.strictEqual(case3.siteVisit.start.dateTime, '2025-09-11T09:00:00.000Z');
+				assert.strictEqual(case3.siteVisit.end.dateTime, '2025-09-11T12:00:00.000Z');
+				assert.strictEqual(case4.siteVisit.start.dateTime, '2025-09-11T12:00:00.000Z');
+				assert.strictEqual(case4.siteVisit.end.dateTime, '2025-09-11T15:00:00.000Z');
+				assert.strictEqual(case5.siteVisit.start.dateTime, '2025-09-12T09:00:00.000Z');
+				assert.strictEqual(case5.siteVisit.end.dateTime, '2025-09-12T12:00:00.000Z');
+				assert.strictEqual(case1.report.start.dateTime, '2025-09-15T09:00:00.000Z');
+				assert.strictEqual(case1.report.end.dateTime, '2025-09-15T11:00:00.000Z');
+				assert.strictEqual(case2.report.start.dateTime, '2025-09-15T11:00:00.000Z');
+				assert.strictEqual(case2.report.end.dateTime, '2025-09-15T13:00:00.000Z');
+				assert.strictEqual(case3.report.start.dateTime, '2025-09-15T13:00:00.000Z');
+				assert.strictEqual(case3.report.end.dateTime, '2025-09-15T15:00:00.000Z');
+				assert.strictEqual(case4.report.start.dateTime, '2025-09-15T15:00:00.000Z');
+				assert.strictEqual(case4.report.end.dateTime, '2025-09-15T17:00:00.000Z');
+				assert.strictEqual(case5.report.start.dateTime, '2025-09-16T09:00:00.000Z');
+				assert.strictEqual(case5.report.end.dateTime, '2025-09-16T11:00:00.000Z');
+				assert.strictEqual(case1.costs.start.dateTime, '2025-09-17T09:00:00.000Z');
+				assert.strictEqual(case1.costs.end.dateTime, '2025-09-17T10:00:00.000Z');
+				assert.strictEqual(case2.costs.start.dateTime, '2025-09-17T10:00:00.000Z');
+				assert.strictEqual(case2.costs.end.dateTime, '2025-09-17T11:00:00.000Z');
+				assert.strictEqual(case3.costs.start.dateTime, '2025-09-17T11:00:00.000Z');
+				assert.strictEqual(case3.costs.end.dateTime, '2025-09-17T12:00:00.000Z');
+				assert.strictEqual(case4.costs.start.dateTime, '2025-09-17T12:00:00.000Z');
+				assert.strictEqual(case4.costs.end.dateTime, '2025-09-17T13:00:00.000Z');
+				assert.strictEqual(case5.costs.start.dateTime, '2025-09-17T13:00:00.000Z');
+				assert.strictEqual(case5.costs.end.dateTime, '2025-09-17T14:00:00.000Z');
+			});
+			it('assignments should wrap onto the next month elegantly', async () => {
+				mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementationOnce(() => {
+					return [
+						{
+							id: 1,
+							caseType: 'H',
+							caseProcedure: 'W',
+							allocationLevel: 'B',
+							CalendarEventTiming: { prepTime: 4, siteVisitTime: 10, reportTime: 5, costsTime: 1 }
+						}
+					];
+				});
+
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-26', [1, 2, 3]);
+				assert.strictEqual(res.length, 15);
+
+				const [case1, case2, case3] = [
+					{ prep: res[0], siteVisit1: res[3], siteVisit2: res[4], report: res[9], costs: res[12] },
+					{ prep: res[1], siteVisit1: res[5], siteVisit2: res[6], report: res[10], costs: res[13] },
+					{ prep: res[2], siteVisit1: res[7], siteVisit2: res[8], report: res[11], costs: res[14] }
+				];
+
+				assert.strictEqual(case1.prep.start.dateTime, '2025-09-25T09:00:00.000Z');
+				assert.strictEqual(case1.prep.end.dateTime, '2025-09-25T13:00:00.000Z');
+				assert.strictEqual(case2.prep.start.dateTime, '2025-09-25T13:00:00.000Z');
+				assert.strictEqual(case2.prep.end.dateTime, '2025-09-25T17:00:00.000Z');
+				assert.strictEqual(case3.prep.start.dateTime, '2025-09-24T09:00:00.000Z');
+				assert.strictEqual(case3.prep.end.dateTime, '2025-09-24T13:00:00.000Z');
+				assert.strictEqual(case1.siteVisit1.start.dateTime, '2025-09-26T09:00:00.000Z');
+				assert.strictEqual(case1.siteVisit1.end.dateTime, '2025-09-26T17:00:00.000Z');
+				assert.strictEqual(case1.siteVisit2.start.dateTime, '2025-09-29T09:00:00.000Z');
+				assert.strictEqual(case1.siteVisit2.end.dateTime, '2025-09-29T11:00:00.000Z');
+				assert.strictEqual(case2.siteVisit1.start.dateTime, '2025-09-30T09:00:00.000Z');
+				assert.strictEqual(case2.siteVisit1.end.dateTime, '2025-09-30T17:00:00.000Z');
+				assert.strictEqual(case2.siteVisit2.start.dateTime, '2025-10-01T09:00:00.000Z');
+				assert.strictEqual(case2.siteVisit2.end.dateTime, '2025-10-01T11:00:00.000Z');
+				assert.strictEqual(case3.siteVisit1.start.dateTime, '2025-10-02T09:00:00.000Z');
+				assert.strictEqual(case3.siteVisit1.end.dateTime, '2025-10-02T17:00:00.000Z');
+				assert.strictEqual(case3.siteVisit2.start.dateTime, '2025-10-03T09:00:00.000Z');
+				assert.strictEqual(case3.siteVisit2.end.dateTime, '2025-10-03T11:00:00.000Z');
+				assert.strictEqual(case1.report.start.dateTime, '2025-10-06T09:00:00.000Z');
+				assert.strictEqual(case1.report.end.dateTime, '2025-10-06T14:00:00.000Z');
+				assert.strictEqual(case2.report.start.dateTime, '2025-10-07T09:00:00.000Z');
+				assert.strictEqual(case2.report.end.dateTime, '2025-10-07T14:00:00.000Z');
+				assert.strictEqual(case3.report.start.dateTime, '2025-10-08T09:00:00.000Z');
+				assert.strictEqual(case3.report.end.dateTime, '2025-10-08T14:00:00.000Z');
+				assert.strictEqual(case1.costs.start.dateTime, '2025-10-09T09:00:00.000Z');
+				assert.strictEqual(case1.costs.end.dateTime, '2025-10-09T10:00:00.000Z');
+				assert.strictEqual(case2.costs.start.dateTime, '2025-10-09T10:00:00.000Z');
+				assert.strictEqual(case2.costs.end.dateTime, '2025-10-09T11:00:00.000Z');
+				assert.strictEqual(case3.costs.start.dateTime, '2025-10-09T11:00:00.000Z');
+				assert.strictEqual(case3.costs.end.dateTime, '2025-10-09T12:00:00.000Z');
+			});
+		});
+		describe('missing stages', () => {
+			it('should be able to elegantly handle timing rules with zero time for a stage', async () => {
+				mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementationOnce(() => {
+					return [
+						{
+							id: 1,
+							caseType: 'H',
+							caseProcedure: 'W',
+							allocationLevel: 'B',
+							CalendarEventTiming: { prepTime: 3, siteVisitTime: 6, reportTime: 4, costsTime: 0 }
+						}
+					];
+				});
+				const service = mockService();
+				const res = await generateCaseCalendarEvents(service, '2025-09-24', [1]);
+				const caseEvents = { prep: res[0], siteVisit: res[1], report: res[2] };
+
+				requiredProps(caseEvents.prep);
+				assert.strictEqual(res.length, 3);
+			});
 		});
 	});
 });

--- a/apps/web/src/app/calendar/types.d.ts
+++ b/apps/web/src/app/calendar/types.d.ts
@@ -28,8 +28,8 @@ export interface CalendarEventInput {
 	};
 	location: {
 		address: {
-			street: string;
-			postalCode: string;
+			street: string | null;
+			postalCode: string | null;
 		};
 	};
 	extensions: [
@@ -40,4 +40,9 @@ export interface CalendarEventInput {
 			eventType?: string;
 		}
 	];
+}
+
+export interface BookedEventTimeslot {
+	startTime: Date;
+	endTime: Date;
 }

--- a/apps/web/src/app/views/cases/controller.test.js
+++ b/apps/web/src/app/views/cases/controller.test.js
@@ -12,23 +12,36 @@ describe('controller.js', () => {
 			mockCasesClient.getLinkedCasesByParentCaseId.mock.resetCalls();
 			mockCalendarClient.getAllCalendarEventTimingRules.mock.resetCalls();
 		});
+		//mock clients
 		const mockCasesClient = {
 			getCaseById: mock.fn(),
 			getLinkedCasesByParentCaseId: mock.fn(),
 			deleteCases: mock.fn()
 		};
-		const appeal = { caseId: 'caseId', linkedCaseStatus: 'child', caseType: 'H', caseProcedure: 'W', caseLevel: 'B' };
-		mockCasesClient.getCaseById.mock.mockImplementation(() => appeal);
 		const mockCbosApiClient = {
 			patchAppeal: mock.fn(),
 			fetchAppealDetails: mock.fn()
 		};
-		const mockGetCbosApiClientForSession = mock.fn();
-		mockGetCbosApiClientForSession.mock.mockImplementation(() => mockCbosApiClient);
-
-		const mockCalendarClient = {
-			getAllCalendarEventTimingRules: mock.fn()
+		const mockEntraClientInstance = {
+			listAllUserCalendarEvents: mock.fn()
 		};
+		const mockGetCbosApiClientForSession = mock.fn();
+		const mockCalendarClient = {
+			getAllCalendarEventTimingRules: mock.fn(),
+			getEnglandWalesBankHolidays: mock.fn()
+		};
+		const mockService = () => {
+			return {
+				logger: mockLogger(),
+				getCbosApiClientForSession: mockGetCbosApiClientForSession,
+				casesClient: mockCasesClient,
+				calendarClient: mockCalendarClient,
+				entraClient: mock.fn(() => mockEntraClientInstance)
+			};
+		};
+
+		//mock data responses
+		const appeal = { caseId: 'caseId', linkedCaseStatus: 'child', caseType: 'H', caseProcedure: 'W', caseLevel: 'B' };
 		const mockTimingRule = {
 			id: 1,
 			caseType: 'H',
@@ -36,15 +49,42 @@ describe('controller.js', () => {
 			allocationLevel: 'B',
 			CalendarEventTiming: { prepTime: 2, siteVisitTime: 3, reportTime: 2, costsTime: 1 }
 		};
+		const [event1, event2] = [
+			{
+				id: 'caseId',
+				subject: 'test case',
+				start: {
+					dateTime: new Date('2025-08-08T12:00:00.000Z'),
+					timeZone: 'UTC'
+				},
+				end: {
+					dateTime: new Date('2025-08-08T14:00:00.000Z'),
+					timeZone: 'UTC'
+				},
+				sensitivity: 'normal'
+			},
+			{
+				id: 'caseId2',
+				subject: 'test case 2',
+				start: {
+					dateTime: new Date('2025-08-09T11:00:00.000Z'),
+					timeZone: 'UTC'
+				},
+				end: {
+					dateTime: new Date('2025-08-09T15:00:00.000Z'),
+					timeZone: 'UTC'
+				},
+				sensitivity: 'normal'
+			}
+		];
+		const existingEvents = [event1, event2];
+
+		//mock implementations
+		mockCasesClient.getCaseById.mock.mockImplementation(() => appeal);
+		mockGetCbosApiClientForSession.mock.mockImplementation(() => mockCbosApiClient);
+		mockCalendarClient.getEnglandWalesBankHolidays.mock.mockImplementation(() => []);
+		mockEntraClientInstance.listAllUserCalendarEvents.mock.mockImplementation(() => existingEvents);
 		mockCalendarClient.getAllCalendarEventTimingRules.mock.mockImplementation(() => [mockTimingRule]);
-		const mockService = () => {
-			return {
-				logger: mockLogger(),
-				getCbosApiClientForSession: mockGetCbosApiClientForSession,
-				casesClient: mockCasesClient,
-				calendarClient: mockCalendarClient
-			};
-		};
 
 		test('should update one case', async () => {
 			const appealsDetailsList = [{ appealId: 1, appealReference: '1' }];

--- a/packages/lib/data/database/calendar-client.js
+++ b/packages/lib/data/database/calendar-client.js
@@ -26,4 +26,18 @@ export class CalendarClient {
 			}
 		});
 	}
+
+	/** @typedef {{division: string, events: {title: string, date: string, notes: string, bunting: true}[]}} BankHolidayJsonDivision */
+	/** @typedef {{'england-and-wales': BankHolidayJsonDivision, 'scotland': BankHolidayJsonDivision, 'northern-ireland': BankHolidayJsonDivision}} BankHolidayJson */
+
+	/**
+	 * Uses a .gov api to fetch a list of uk bank holidays
+	 * @returns {Promise<string[]>}
+	 */
+	async getEnglandWalesBankHolidays() {
+		const res = await fetch('https://www.gov.uk/bank-holidays.json');
+		/** @type {BankHolidayJson} */
+		const bankHolidayJson = await res.json();
+		return bankHolidayJson['england-and-wales'].events.map((e) => e.date);
+	}
 }


### PR DESCRIPTION
## Describe your changes
So this is quite a big ticket as you can probably see. It is responsible mainly for taking in up to 10 cases and a date and then automatically allocating times for calendar events for the inspector around the given date. It has lots of internal logic to it which I will attempt to describe here:

- We go through each CASE in each STAGE, not the other way around. This is to enforce a 'grouping' between stages as we want to group up our stages together. E.g. dont want prep events allocated in the middle of our site visits. THis does mean we call getCaseById a lot but this will be cached after the first call so this is fine
- We enforce a few rules on allocations described in the ACs but the main ones are: no more than 8 hours allocated per day, events longer than 8 hours to be split up, no events on bank holidays or weekends.
- Sophie mentioned on the ticket that we should assume the calendars are empty e.g. ignore any existing events in their calendar. This came as a blessing BUT the way this is structured should make this easy to implement, because I already did! The bank holidays assignment logic I actually adapted straight from this and so by just doing something like spreading an array of start dates and end dates of existing events right in with the bank holiday start and end dates this should work well. Not for this ticket but useful for future reference!
- This is all configured to use UTC.

You may notice that calendar.test.js is absolutely enormous. I definitely did put test driven development into practice here. Please do take a look at the test scenarios and if you can think of any scenarios I may have missed please do mention.

couple of todos:
- I am aware of two ACs that still need doing: firstly that I believe all report events should all be plotted in on the same time slot at 9am. i wasnt aware of this when I was working on it so i will work this in afterwards. 
- Also I know we discussed switching over to bank holidays from the DB which I havent gotten around to implementing, it still uses the api.

Also a small feature for testing in dev; I added a config to bypass the requirement for inspectors to appear in the local db as well as entra. This means you will be able to use yourself in entra as an inspector and check the live calendar which will be a bit more useful.

## Issue ticket number and link
https://pins-ds.atlassian.net.mcas.ms/jira/software/projects/PPB/boards/373?selectedIssue=PPB-157