### PR TITLE
fix: logs to output error message instead of error object

### DIFF
--- a/packages/lib/data/cbos/cbos-api-client.js
+++ b/packages/lib/data/cbos/cbos-api-client.js
@@ -52,8 +52,8 @@ export class CbosApiClient {
 
 			return { cases: mappedAppeals, caseReferences: filteredCaseReferences };
 		} catch (error) {
-			this.logger.error({ error: error }, '[CaseController] Error fetching case details');
-			throw new Error('Failed to fetch cases. Please try again later.');
+			this.logger.error({ error: error.message }, '[CaseController] Error fetching case details');
+			throw new Error(error.message);
 		}
 	}
 


### PR DESCRIPTION
## Describe your changes

- Log error.message instead of error
- Throw error with original error message

## Issue ticket number and link
