### PR TITLE
fix: don't fetch calendar event extensions for inspectors calendar view

### DIFF
--- a/apps/web/src/app/api/endpoints/events/controller.js
+++ b/apps/web/src/app/api/endpoints/events/controller.js
@@ -53,7 +53,8 @@ export function getCalendarEventsForEntraUsers(service) {
 					userChunk.map(async (user) => {
 						const usersEvents = await apiService.entraClient.listAllUserCalendarEvents(user.id, {
 							calendarEventsDayRange: calendarEventsDayRange,
-							calendarEventsFromDateOffset: calendarEventsFromDateOffset
+							calendarEventsFromDateOffset: calendarEventsFromDateOffset,
+							fetchExtension: true
 						});
 
 						//format returned events for PowerBI

--- a/packages/lib/graph/cached-entra-client.js
+++ b/packages/lib/graph/cached-entra-client.js
@@ -70,17 +70,18 @@ export class CachedEntraClient {
 	/**
 	 *
 	 * @param {string} userId
+	 * @param {boolean} [fetchExtension]
 	 * @returns {Promise<import('./types').CalendarEvents>}
 	 */
-	async getUserCalendarEvents(userId) {
-		return this.#client.getUserCalendarEvents(userId);
+	async getUserCalendarEvents(userId, fetchExtension) {
+		return this.#client.getUserCalendarEvents(userId, fetchExtension);
 	}
 
 	/**
 	 * Fetch all calendar events for an Entra user ID, up to a maximum of 5000
 	 *
 	 * @param {string} userId
-	 * @param {{calendarEventsDayRange: number, calendarEventsFromDateOffset: number}} options
+	 * @param {{calendarEventsDayRange: number, calendarEventsFromDateOffset: number, fetchExtension?: boolean}} options
 	 * @returns {Promise<import('./types.js').CalendarEvent[]>}
 	 */
 	async listAllUserCalendarEvents(userId, options) {


### PR DESCRIPTION
## Describe your changes

Inspector calendars weren't showing because delegate permissions doesn't seem to allow fetching extensions. They are not used for the in-app calendar view so have been made optional.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/PPB-229
