### PR TITLE
feat/ppb-225-match-map-view-to-refreshed-case-list

### DIFF
--- a/apps/web/src/app/views/home/view.njk
+++ b/apps/web/src/app/views/home/view.njk
@@ -61,6 +61,9 @@
                     type: "submit"
                 }) }}
             </div>
+            {{ compileFilterQueryFields(filters) }}
+            {{ compileSortPaginationQueryFields(filters) }}
+            <input type="hidden" name="page" value="{{ filters.query.page }}">
         </form>
         <div class="app-filter__content">
             <div class="app-filter__options">


### PR DESCRIPTION
## Describe your changes
Notice that when we switch to map view that we re-render the page and that none of the page queries were being submitted  in the form that re-renders the page. I have adjusted this so that filters changed on the home page are now reflected in the map

## Issue ticket number and link
https://pins-ds.atlassian.net.mcas.ms/jira/software/projects/PPB/boards/373?selectedIssue=PPB-225