### PR TITLE
feat/ppb-235 - hide fields on private events in PowerBI

### DIFF
--- a/apps/web/src/app/api/endpoints/events/controller.js
+++ b/apps/web/src/app/api/endpoints/events/controller.js
@@ -121,7 +121,7 @@ function formatCalendarEvent(event, user) {
 	return {
 		id: event.id,
 		userEmail: user.email,
-		title: event.subject,
+		title: event.sensitivity === 'private' ? 'Private Event' : event.subject,
 		startDate: event.start?.dateTime || 'N/A',
 		endDate: event.end?.dateTime || 'N/A',
 		isAllDay: !!event.isAllDay,


### PR DESCRIPTION
## Describe your changes
We only want a very select amount of fields visible in /events PowerBI api for private events.

## Issue ticket number and link
https://pins-ds.atlassian.net.mcas.ms/browse/PPB-235