### PR TITLE
fix/PPB-404-remove-incorrect-case-type-options

### DIFF
--- a/apps/web/src/app/views/home/view-model.js
+++ b/apps/web/src/app/views/home/view-model.js
@@ -277,8 +277,12 @@ export function toInspectorViewModel(inspector) {
 	};
 }
 
+/** Case types to exclude from the Case Type filter */
+const excludedCaseTypes = [APPEAL_CASE_TYPE.L, APPEAL_CASE_TYPE.S];
+
 /** @type {import('#util/types.js').RadioOption[]} */
 export const caseTypeOptions = Object.values(appealTypes)
+	.filter((v) => !excludedCaseTypes.includes(v.key))
 	.map((v) => {
 		const shorthand = shortCaseType(v.key);
 		let text = v.changeAppealType;

--- a/apps/web/src/app/views/home/view-model.test.js
+++ b/apps/web/src/app/views/home/view-model.test.js
@@ -518,9 +518,21 @@ describe('view-model', () => {
 	describe('caseTypeOptions', () => {
 		test('should include type shorthand in brackets', () => {
 			assert.strictEqual(caseTypeOptions[0].text, 'Advertisement (Adv)');
-			assert.strictEqual(caseTypeOptions[3].text, 'Commercial advertisement (CAS Ad)');
+			assert.strictEqual(caseTypeOptions[2].text, 'Commercial advertisement (CAS Ad)');
 			// expect if the shorthand matches the name
-			assert.strictEqual(caseTypeOptions[11].text, 'Planning');
+			assert.strictEqual(caseTypeOptions[9].text, 'Planning');
+		});
+
+		test('should not include CIL or Affordable Housing options', () => {
+			const texts = caseTypeOptions.map((o) => o.text);
+			assert.strictEqual(
+				texts.some((t) => t.includes('Community infrastructure levy')),
+				false
+			);
+			assert.strictEqual(
+				texts.some((t) => t.includes('Affordable housing')),
+				false
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Describe your changes
Removed the `Community infrastructure levy (CIL)` and `Affordable housing` options from the case type filter.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/PPB-404