### PR TITLE
chore(infrastructure): adding private endpoint for SQL storage accounts

### DIFF
--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -62,6 +62,13 @@ data "azurerm_private_dns_zone" "keyvault" {
   provider = azurerm.tooling
 }
 
+data "azurerm_private_dns_zone" "storage" {
+  name                = "privatelink.blob.core.windows.net"
+  resource_group_name = var.tooling_config.network_rg
+
+  provider = azurerm.tooling
+}
+
 data "azurerm_linux_web_app" "cbos_api" {
   name                = var.manage_appeals_config.api_app_name
   resource_group_name = var.manage_appeals_config.resource_group_name

--- a/infrastructure/database-monitoring.tf
+++ b/infrastructure/database-monitoring.tf
@@ -21,9 +21,36 @@ resource "azurerm_storage_account" "sql_server" {
   https_traffic_only_enabled       = true
   allow_nested_items_to_be_public  = false
   cross_tenant_replication_enabled = false
+  public_network_access_enabled    = false
+
+  network_rules {
+    default_action = "Deny"
+    bypass         = ["AzureServices"]
+  }
 
   identity {
     type = "SystemAssigned"
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_private_endpoint" "sql_storage" {
+  name                = "${local.org}-pe-st-sql-${local.resource_suffix}"
+  location            = module.primary_region.location
+  resource_group_name = azurerm_resource_group.primary.name
+  subnet_id           = azurerm_subnet.main.id
+
+  private_dns_zone_group {
+    name                 = "${local.org}-pdns-${local.service_name}-storage-${var.environment}"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.storage.id]
+  }
+
+  private_service_connection {
+    name                           = "${local.org}-psc-storage-${local.resource_suffix}"
+    private_connection_resource_id = azurerm_storage_account.sql_server.id
+    subresource_names              = ["blob"]
+    is_manual_connection           = false
   }
 
   tags = local.tags
@@ -54,12 +81,11 @@ resource "azurerm_role_assignment" "sql_server_storage" {
 
 # auditing policy
 resource "azurerm_mssql_server_extended_auditing_policy" "sql_server" {
-  enabled                    = true
-  storage_endpoint           = azurerm_storage_account.sql_server.primary_blob_endpoint
-  storage_account_access_key = azurerm_storage_account.sql_server.primary_access_key
-  server_id                  = azurerm_mssql_server.primary.id
-  retention_in_days          = var.sql_config.retention.audit_days
-  log_monitoring_enabled     = false
+  enabled                = true
+  storage_endpoint       = azurerm_storage_account.sql_server.primary_blob_endpoint
+  server_id              = azurerm_mssql_server.primary.id
+  retention_in_days      = var.sql_config.retention.audit_days
+  log_monitoring_enabled = false
 
   depends_on = [
     azurerm_role_assignment.sql_server_storage,
@@ -89,7 +115,6 @@ resource "azurerm_mssql_server_vulnerability_assessment" "scheduling_sql_server"
 
   server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.sql_server.id
   storage_container_path          = "${azurerm_storage_account.sql_server.primary_blob_endpoint}${azurerm_storage_container.sql_server.name}/"
-  storage_account_access_key      = azurerm_storage_account.sql_server.primary_access_key
 
   recurring_scans {
     enabled                   = var.alerts_enabled

--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -108,3 +108,12 @@ resource "azurerm_private_dns_zone_virtual_network_link" "keyvault" {
 
   provider = azurerm.tooling
 }
+
+resource "azurerm_private_dns_zone_virtual_network_link" "storage" {
+  name                  = "${local.org}-vnetlink-storage-${local.resource_suffix}"
+  resource_group_name   = var.tooling_config.network_rg
+  private_dns_zone_name = data.azurerm_private_dns_zone.storage.name
+  virtual_network_id    = azurerm_virtual_network.main.id
+
+  provider = azurerm.tooling
+}


### PR DESCRIPTION
## Describe your changes

Adding private endpoint for SQL storage accounts - which hold audit policy, vulnerability assessment for SQL servers

Below changes are added in this commit

- Adding a data block for blob private DNS Zone
- Setting public access as false and adding network cls to bypass Azure Services in Storage configuration
- Adding private endpoint definition
- Adding vnet link between private DNS zone and inspector programming virtual network
- Removing storage_account_access_key field in auditing policy, vulnerability assessment

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/DEV-669
