### PR TITLE
fix/case-detail-map-not-loading

### DIFF
--- a/apps/web/src/app/views/case/view.njk
+++ b/apps/web/src/app/views/case/view.njk
@@ -59,7 +59,7 @@
         }) }}
 
         <div class="map-container">
-            {{ osMap(map.apiKey, [caseData], inspectorPin) }}
+            {{ osMap(map.apiKey, cbosUrl, [caseData], inspectorPin) }}
 
         </div>
     </div>


### PR DESCRIPTION
## Describe your changes
Updated osMap to include cbosUrl  in case details page 

## Issue ticket number and link
Related to [PPB‑440](https://pins-ds.atlassian.net/browse/PPB-440).
The case details page was not passing cbosUrl to osMap, which caused the map to fail to load.
