### PR TITLE
fix/PPB-421-outlook-location-info

### DIFF
--- a/packages/lib/data/database/cases-client.js
+++ b/packages/lib/data/database/cases-client.js
@@ -138,6 +138,7 @@ export class CasesClient {
 			typeOfPlanningApplication: c.typeOfPlanningApplication || null,
 			applicationDecision: c.applicationDecision || null,
 			eventType: c.eventType || null,
+			siteAddressLine1: c.siteAddressLine1 || null,
 
 			// costs
 			appellantCostsAppliedFor: c.appellantCostsAppliedFor,

--- a/packages/lib/data/database/cases-client.test.js
+++ b/packages/lib/data/database/cases-client.test.js
@@ -129,6 +129,7 @@ describe('CasesClient', () => {
 					typeOfPlanningApplication: 'prior-approval',
 					applicationDecision: 'refused',
 					eventType: APPEAL_EVENT_TYPE.SITE_VISIT_ACCOMPANIED,
+					siteAddressLine1: '123 Example Street',
 					appellantCostsAppliedFor: null,
 					lpaCostsAppliedFor: true
 				},
@@ -158,6 +159,7 @@ describe('CasesClient', () => {
 					typeOfPlanningApplication: 'prior-approval',
 					applicationDecision: null,
 					eventType: null,
+					siteAddressLine1: '123 Example Road',
 					appellantCostsAppliedFor: null,
 					lpaCostsAppliedFor: null
 				}


### PR DESCRIPTION
## Describe your changes
Add siteAddressLine1 to case data structure in cases-client.

Tested with User One Inspector (Test). The location displays correctly after assigning the case to Inspector 1, as shown in the attached image.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/PPB-421


<img width="1724" height="1117" alt="Screenshot 2026-07-13 140907" src="https://github.com/user-attachments/assets/06735673-797e-4a27-b3fd-05bed4a837a3" />

<img width="1802" height="921" alt="Screenshot 2026-07-13 140938" src="https://github.com/user-attachments/assets/d99504a1-ec0d-4696-997c-5b8b1b79b1ec" />

