### PR TITLE
feature/ppb-423-indicate-inspector-selection

### DIFF
--- a/apps/web/src/app/views/home/view.njk
+++ b/apps/web/src/app/views/home/view.njk
@@ -413,7 +413,11 @@
                     </div>
                     <form method="post" action="/cases" novalidate>
                         <input type="hidden" name="inspectorId" value="{{ filters.query.inspectorId }}">
+                    {% if inspectors.selected %}
                         <div class="assignment-form">
+                            <p class="govuk-body govuk-!-margin-top-2 govuk-!-margin-right-2">
+                                You are assigning cases for {{ inspectors.selected.lastName }}, {{ inspectors.selected.firstName }}.
+                            </p>
                             <div class="govuk-form-group {% if appeals.assignmentDateError %} margin-top-error-40px {% endif %}">
                                 <label class="govuk-label" for="assignment-date">Event date: </label>
                             </div>
@@ -437,6 +441,12 @@
                                 }) }}
                             </div>
                         </div>
+                    {% else %}
+                        <p class="govuk-body govuk-!-text-align-right">
+                            Select an inspector to assign cases
+                        </p>
+                    {% endif %}
+
                         {% include 'views/home/cases-table.njk' %}
                     </form>
 


### PR DESCRIPTION
## Describe your changes
- Hide event date and assignment button until an inspector has been selected
- Add a “You are assigning cases for inspector” message

<img width="1890" height="662" alt="Screenshot 2026-07-16 170553" src="https://github.com/user-attachments/assets/d91dc28a-91a6-45f3-905e-ba187a74a8d3" />

<img width="1933" height="585" alt="Screenshot 2026-07-16 170358" src="https://github.com/user-attachments/assets/2dccc999-fb45-4cac-99ef-8d87c9e98164" />



## Issue ticket number and link
https://pins-ds.atlassian.net/browse/PPB-423
