### PR TITLE
fix/PPB-461-case-selection-persists-after-assignment-failure

### DIFF
--- a/apps/web/src/app/views/home/controller.js
+++ b/apps/web/src/app/views/home/controller.js
@@ -121,14 +121,6 @@ export function buildViewHome(service, getEventsFunction) {
 		const isCalendarTab = req.query.currentTab === 'calendar';
 		const isInspectorTab = req.query.currentTab === 'inspector';
 
-		const selectedCaseIds = readSessionData(req, 'caseListData', 'selectedCases', [], 'persistence');
-		for (let caseId of selectedCaseIds) {
-			let caseIndex = cases.findIndex((item) => item.caseId === parseInt(caseId));
-			if (caseIndex !== -1) {
-				cases[caseIndex].selected = true;
-			}
-		}
-
 		// get output from /cases
 		const selectInspectorError = readSessionData(req, 'errors', 'selectInspectorError', false, 'persistence');
 		const successSummary = readSessionData(req, 'success', 'successSummary', null, 'persistence');

--- a/apps/web/src/app/views/home/controller.test.js
+++ b/apps/web/src/app/views/home/controller.test.js
@@ -227,38 +227,6 @@ describe('controller.js', () => {
 			assert.strictEqual(args.appeals?.cases?.length, 10);
 		});
 
-		test('should mark cases as selected based on session data', async () => {
-			const service = mockService();
-			service.casesClient.getCases.mock.mockImplementationOnce(() => ({
-				cases: [
-					{ caseId: 101, id: 1 },
-					{ caseId: 102, id: 2 },
-					{ caseId: 103, id: 3 }
-				],
-				total: 3
-			}));
-			const req = {
-				url: '/',
-				query: {},
-				session: {
-					persistence: {
-						caseListData: {
-							selectedCases: ['101', '103']
-						}
-					}
-				}
-			};
-			const res = { render: mock.fn() };
-			const controller = buildViewHome(service, service.getSimplifiedEvents);
-			await controller(req, res);
-			assert.strictEqual(res.render.mock.callCount(), 1);
-			const args = res.render.mock.calls[0].arguments[1];
-			assert.strictEqual(args.appeals?.cases?.length, 3);
-			assert.strictEqual(args.appeals.cases[0].selected, true);
-			assert.strictEqual(args.appeals.cases[1].selected, undefined);
-			assert.strictEqual(args.appeals.cases[2].selected, true);
-		});
-
 		test('should show error when on inspector tab without inspector selected', async () => {
 			const service = mockService();
 			service.casesClient.getCases.mock.mockImplementationOnce(() => ({

--- a/apps/web/src/app/views/home/view.js
+++ b/apps/web/src/app/views/home/view.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', function () {
 	homeLinks.forEach(function (link) {
 		link.addEventListener('click', function () {
 			try {
-				sessionStorage.removeItem('selectedCases');
+				sessionStorage.removeItem(SELECTED_CASES_KEY);
 			} catch {
 				// Intentionally ignored - sessionStorage may not be available
 			}


### PR DESCRIPTION

## Describe your changes
Remove the session‑based case‑selection persistence logic, which was causing selected cases to remain after an assignment failure. 

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/PPB-461